### PR TITLE
feat: add github command as optional plugin

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Install shards
         run: shards install
 
-      - name: Build executable
+      - name: Build executable (default)
         run: |
           mkdir -p bin
           if [ "${{ matrix.os }}" = "windows-latest" ]; then
@@ -54,25 +54,40 @@ jobs:
           fi
         shell: bash
 
+      - name: Build executable (with github plugin)
+        run: |
+          if [ "${{ matrix.os }}" = "windows-latest" ]; then
+            crystal build src/main.cr -o bin/milka-github.exe --release --no-debug -Dgithub_plugin
+          else
+            crystal build src/main.cr -o bin/milka-github --release --no-debug -Dgithub_plugin
+          fi
+        shell: bash
+
       - name: Package release asset
         run: |
-          # Create a zip archive containing the executable
+          # Create zip archives containing the executables
           if [ "${{ matrix.platform }}" = "windows" ]; then
             7z a -tzip "milka-${{ matrix.target }}.zip" "bin/milka.exe"
+            7z a -tzip "milka-github-${{ matrix.target }}.zip" "bin/milka-github.exe"
           else
             cp bin/milka milka
             zip -r "milka-${{ matrix.target }}.zip" milka
-            rm milka  # Clean up the copied file
+            rm milka
+            cp bin/milka-github milka-github
+            zip -r "milka-github-${{ matrix.target }}.zip" milka-github
+            rm milka-github
           fi
 
-          # Generate checksum for the archive
-          if command -v sha256sum > /dev/null; then
-            sha256sum "milka-${{ matrix.target }}.zip" > "milka-${{ matrix.target }}.zip.sha256"
-          elif command -v shasum > /dev/null; then
-            shasum -a 256 "milka-${{ matrix.target }}.zip" > "milka-${{ matrix.target }}.zip.sha256"
-          elif command -v certutil > /dev/null; then
-            certutil -hashfile "milka-${{ matrix.target }}.zip" SHA256 > "milka-${{ matrix.target }}.zip.sha256"
-          fi
+          # Generate checksums for the archives
+          for file in milka-${{ matrix.target }}.zip milka-github-${{ matrix.target }}.zip; do
+            if command -v sha256sum > /dev/null; then
+              sha256sum "$file" > "$file.sha256"
+            elif command -v shasum > /dev/null; then
+              shasum -a 256 "$file" > "$file.sha256"
+            elif command -v certutil > /dev/null; then
+              certutil -hashfile "$file" SHA256 > "$file.sha256"
+            fi
+          done
         shell: bash
 
       - name: Release
@@ -81,5 +96,7 @@ jobs:
           files: |
             milka-${{ matrix.target }}.zip
             milka-${{ matrix.target }}.zip.sha256
+            milka-github-${{ matrix.target }}.zip
+            milka-github-${{ matrix.target }}.zip.sha256
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/static-release.yml
+++ b/.github/workflows/static-release.yml
@@ -32,8 +32,8 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      # Build static binary using container for Linux
-      - name: Build static binary using Alpine container
+      # Build static binary using container for Linux (default)
+      - name: Build static binary using Alpine container (default)
         run: |
           # Build the container and extract the static binary
           docker build -f ./.meta/packaging/static-builds/Containerfile -t milka-static-build .
@@ -44,17 +44,32 @@ jobs:
           docker rmi milka-static-build > /dev/null
           chmod +x ./milka
 
-      # Package the binary
+      # Build static binary with github plugin
+      - name: Build static binary using Alpine container (with github plugin)
+        run: |
+          # Build the container and extract the static binary
+          docker build -f ./.meta/packaging/static-builds/Containerfile.github -t milka-github-static-build .
+          # Create a temporary container to extract the binary
+          docker create --name temp-container-github milka-github-static-build
+          docker cp temp-container-github:/milka-github ./milka-github
+          docker rm -v temp-container-github > /dev/null
+          docker rmi milka-github-static-build > /dev/null
+          chmod +x ./milka-github
+
+      # Package the binaries
       - name: Package release asset
         run: |
           zip -r "milka-${{ matrix.platform }}.zip" "${{ matrix.bin }}"
+          zip -r "milka-github-${{ matrix.platform }}.zip" "milka-github"
 
-          # Generate checksum for the archive
-          if command -v sha256sum > /dev/null; then
-            sha256sum "milka-${{ matrix.platform }}.zip" > "milka-${{ matrix.platform }}.zip.sha256"
-          elif command -v shasum > /dev/null; then
-            shasum -a 256 "milka-${{ matrix.platform }}.zip" > "milka-${{ matrix.platform }}.zip.sha256"
-          fi
+          # Generate checksums for the archives
+          for file in milka-${{ matrix.platform }}.zip milka-github-${{ matrix.platform }}.zip; do
+            if command -v sha256sum > /dev/null; then
+              sha256sum "$file" > "$file.sha256"
+            elif command -v shasum > /dev/null; then
+              shasum -a 256 "$file" > "$file.sha256"
+            fi
+          done
 
       # Upload the release assets
       - name: Release
@@ -63,5 +78,7 @@ jobs:
           files: |
             milka-${{ matrix.platform }}.zip
             milka-${{ matrix.platform }}.zip.sha256
+            milka-github-${{ matrix.platform }}.zip
+            milka-github-${{ matrix.platform }}.zip.sha256
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,14 +21,25 @@ jobs:
       - name: Install shards
         run: shards install
 
-      - name: Run tests
+      - name: Run tests (default build)
         run: crystal spec
 
-      - name: Build executable
+      - name: Run tests (with github plugin)
+        run: crystal spec -Dgithub_plugin
+
+      - name: Build executable (default)
         run: |
           mkdir -p bin
           crystal build src/main.cr -o bin/milka --release --no-debug
 
-      - name: Verify executable
+      - name: Verify executable (default)
         run: |
           ./bin/milka --help
+
+      - name: Build executable (with github plugin)
+        run: |
+          crystal build src/main.cr -o bin/milka-github --release --no-debug -Dgithub_plugin
+
+      - name: Verify executable (with github plugin)
+        run: |
+          ./bin/milka-github --help

--- a/.meta/packaging/static-builds/Containerfile.github
+++ b/.meta/packaging/static-builds/Containerfile.github
@@ -1,0 +1,17 @@
+FROM crystallang/crystal:1-alpine
+
+WORKDIR /app
+
+COPY . .
+
+RUN shards install --without-development
+
+RUN mkdir -p bin
+
+RUN crystal build src/main.cr -o bin/milka-github --static --release --no-debug -Dgithub_plugin
+
+FROM scratch
+
+COPY --from=0 /app/bin/milka-github /milka-github
+
+CMD ["/milka-github"]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: https://github.com/kogeletey/milka/issues/1
-Your prepared branch: issue-1-530cc4f55dc5
-Your prepared working directory: /tmp/gh-issue-solver-1766667232489
-Your forked repository: konard/kogeletey-milka
-Original repository (upstream): kogeletey/milka
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+Issue to solve: https://github.com/kogeletey/milka/issues/1
+Your prepared branch: issue-1-530cc4f55dc5
+Your prepared working directory: /tmp/gh-issue-solver-1766667232489
+Your forked repository: konard/kogeletey-milka
+Original repository (upstream): kogeletey/milka
+
+Proceed.

--- a/README.md
+++ b/README.md
@@ -26,9 +26,15 @@ source = 'git+subtree'  # For subtree operations (new feature!)
 
 **New Feature: Subtree Support** - Use the `--subtree` flag to work only with repositories that have `source = "git+subtree"` in your configuration!
 
-## 🚀 Version 2025.11.7 Highlights (Latest Release)
+## 🚀 Version 2025.11.8 Highlights (Latest Release)
 
-- **New `github` command**: Scan and clone all repositories from a GitHub organization or user with `milka github <org-name>`
+- **Plugin architecture for github command**: The `github` command is now an optional plugin that can be built separately with `shards build milka-github -Dgithub_plugin`
+- **Leaner default build**: The default `milka` binary no longer includes the GitHub scanning functionality, keeping it lightweight
+- **Easy plugin installation**: Users who need GitHub org/user scanning can build the extended version with a single command
+
+## 🚀 Version 2025.11.7 Highlights
+
+- **New `github` command** (plugin): Scan and clone all repositories from a GitHub organization or user with `milka github <org-name>`
 - **Optional cloning**: Use `milka github <org-name> --clone` to both add repos to config and clone them
 - **GitHub API integration**: Automatic pagination for organizations with many repositories
 - **Token authentication**: Support for `GITHUB_TOKEN` and `GH_TOKEN` environment variables for private repos and higher rate limits
@@ -63,9 +69,9 @@ source = 'git+subtree'  # For subtree operations (new feature!)
 - **Fetch updates** from multiple repositories simultaneously
 - **Pull latest changes** from all configured repositories
 - **Push changes** to multiple repositories at once
-- **Subtree support** - Use git subtree operations with `--subtree` flag (new!)
+- **Subtree support** - Use git subtree operations with `--subtree` flag
 - **Scan** current directory for existing git repositories and add them to configuration
-- **GitHub organization scanning** - Fetch and clone all repositories from a GitHub organization or user
+- **GitHub organization scanning** (plugin) - Fetch and clone all repositories from a GitHub organization or user (requires `-Dgithub_plugin` build flag)
 - **Colored output** for better readability
 - **Spinner indicators** for ongoing operations
 - **Authentication support** for private repositories using personal access tokens
@@ -78,9 +84,13 @@ source = 'git+subtree'  # For subtree operations (new feature!)
 2. Clone this repository
 3. Build the project:
    ```bash
+   # Standard build (without github command)
    shards build
+
+   # Build with GitHub plugin (includes the github command)
+   shards build milka-github -Dgithub_plugin
    ```
-4. The executable will be available as `bin/milka`
+4. The executable will be available as `bin/milka` (or `bin/milka-github` for the plugin version)
 
 ### Pre-built Binaries
 
@@ -211,16 +221,18 @@ milka scan                     # Scan and add git repos to config (with source =
 milka scan --subtree           # Scan and add git repos to config (with source = "git+subtree")
 ```
 
-### `github`
+### `github` (Plugin)
 Scan GitHub organization or user repositories and add them to the configuration file. Optionally clone them as well.
 
+**Note**: This command is only available in the `milka-github` binary built with `-Dgithub_plugin` flag.
+
 ```bash
-milka github myorg             # Scan GitHub org 'myorg' and add all repos to config
-milka github myorg --clone     # Scan and also clone all repositories
-milka github myuser --subtree  # Scan user 'myuser' and add repos with subtree source
+milka-github github myorg             # Scan GitHub org 'myorg' and add all repos to config
+milka-github github myorg --clone     # Scan and also clone all repositories
+milka-github github myuser --subtree  # Scan user 'myuser' and add repos with subtree source
 ```
 
-**Note**: For private repositories or to avoid rate limits, set the `GITHUB_TOKEN` or `GH_TOKEN` environment variable with your GitHub personal access token.
+**Authentication**: For private repositories or to avoid rate limits, set the `GITHUB_TOKEN` or `GH_TOKEN` environment variable with your GitHub personal access token.
 
 ### `help`
 Show usage information.
@@ -278,11 +290,12 @@ milka scan                     # Add repos plane, not git init
 milka scan --subtree           # Add repos with subtree functionality
 ```
 
-Scan and clone all repositories from a GitHub organization:
+Scan and clone all repositories from a GitHub organization (requires plugin build):
 ```bash
-milka github myorg             # Add all org repos to config
-milka github myorg --clone     # Add to config and clone all repos
-GITHUB_TOKEN=your_token milka github private-org --clone  # With authentication
+# Build the plugin version first: shards build milka-github -Dgithub_plugin
+milka-github github myorg             # Add all org repos to config
+milka-github github myorg --clone     # Add to config and clone all repos
+GITHUB_TOKEN=your_token milka-github github private-org --clone  # With authentication
 ```
 
 ## Author

--- a/README.md
+++ b/README.md
@@ -26,7 +26,14 @@ source = 'git+subtree'  # For subtree operations (new feature!)
 
 **New Feature: Subtree Support** - Use the `--subtree` flag to work only with repositories that have `source = "git+subtree"` in your configuration!
 
-## 🚀 Version 2025.11.6 Highlights (Latest Release)
+## 🚀 Version 2025.11.7 Highlights (Latest Release)
+
+- **New `github` command**: Scan and clone all repositories from a GitHub organization or user with `milka github <org-name>`
+- **Optional cloning**: Use `milka github <org-name> --clone` to both add repos to config and clone them
+- **GitHub API integration**: Automatic pagination for organizations with many repositories
+- **Token authentication**: Support for `GITHUB_TOKEN` and `GH_TOKEN` environment variables for private repos and higher rate limits
+
+## 🚀 Version 2025.11.6 Highlights
 
 - **Enhanced error handling**: Improved error messages and handling for repository operations
 - **Performance improvements**: Faster repository scanning and operations with large numbers of repositories
@@ -58,6 +65,7 @@ source = 'git+subtree'  # For subtree operations (new feature!)
 - **Push changes** to multiple repositories at once
 - **Subtree support** - Use git subtree operations with `--subtree` flag (new!)
 - **Scan** current directory for existing git repositories and add them to configuration
+- **GitHub organization scanning** - Fetch and clone all repositories from a GitHub organization or user
 - **Colored output** for better readability
 - **Spinner indicators** for ongoing operations
 - **Authentication support** for private repositories using personal access tokens
@@ -203,6 +211,17 @@ milka scan                     # Scan and add git repos to config (with source =
 milka scan --subtree           # Scan and add git repos to config (with source = "git+subtree")
 ```
 
+### `github`
+Scan GitHub organization or user repositories and add them to the configuration file. Optionally clone them as well.
+
+```bash
+milka github myorg             # Scan GitHub org 'myorg' and add all repos to config
+milka github myorg --clone     # Scan and also clone all repositories
+milka github myuser --subtree  # Scan user 'myuser' and add repos with subtree source
+```
+
+**Note**: For private repositories or to avoid rate limits, set the `GITHUB_TOKEN` or `GH_TOKEN` environment variable with your GitHub personal access token.
+
 ### `help`
 Show usage information.
 
@@ -255,8 +274,15 @@ milka --config /path/to/custom.toml pull
 
 Scan current directory and add git repositories to configuration:
 ```bash
-milka scan                     # Add repos plane, not git init 
+milka scan                     # Add repos plane, not git init
 milka scan --subtree           # Add repos with subtree functionality
+```
+
+Scan and clone all repositories from a GitHub organization:
+```bash
+milka github myorg             # Add all org repos to config
+milka github myorg --clone     # Add to config and clone all repos
+GITHUB_TOKEN=your_token milka github private-org --clone  # With authentication
 ```
 
 ## Author

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: milka
-version: 2025.11.4
+version: 2025.11.7
 
 authors:
   - Konrad Geletey <kg@re128.org>

--- a/shard.yml
+++ b/shard.yml
@@ -1,11 +1,13 @@
 name: milka
-version: 2025.11.7
+version: 2025.11.8
 
 authors:
   - Konrad Geletey <kg@re128.org>
 
 targets:
   milka:
+    main: src/main.cr
+  milka-github:
     main: src/main.cr
 
 dependencies:

--- a/spec/github/github_command_spec.cr
+++ b/spec/github/github_command_spec.cr
@@ -1,3 +1,4 @@
+{% if flag?(:github_plugin) %}
 require "spec"
 require "file_utils"
 require "../../src/milka/types/repository_info"
@@ -108,3 +109,4 @@ describe "github command string parsing" do
     result.should eq(:github)
   end
 end
+{% end %}

--- a/spec/github/github_command_spec.cr
+++ b/spec/github/github_command_spec.cr
@@ -1,0 +1,110 @@
+require "spec"
+require "file_utils"
+require "../../src/milka/types/repository_info"
+require "../../src/milka/types/mise_config"
+require "../../src/milka/types/git_error"
+require "../../src/milka/commands"
+require "../../src/milka/utils"
+require "../../src/milka/config_manager"
+require "../../src/milka/commands/github_command"
+
+# Create temporary directory for test isolation
+GITHUB_CMD_SPEC_TEMP_DIR = File.join(Dir.tempdir, "milka_github_command_spec_#{Time.local.to_unix}")
+
+describe "github command" do
+  before_all do
+    Dir.mkdir_p(GITHUB_CMD_SPEC_TEMP_DIR)
+  end
+
+  after_all do
+    if Dir.exists?(GITHUB_CMD_SPEC_TEMP_DIR)
+      FileUtils.rm_rf(GITHUB_CMD_SPEC_TEMP_DIR)
+    end
+  end
+
+  describe "GithubCommand initialization" do
+    it "should create a command with config path" do
+      temp_dir = File.join(GITHUB_CMD_SPEC_TEMP_DIR, "init_test")
+      Dir.mkdir_p(temp_dir)
+      config_path = File.join(temp_dir, "reps.toml")
+
+      command = GithubCommand.new(config_path)
+      command.should_not be_nil
+    end
+
+    it "should create a command with branch override" do
+      temp_dir = File.join(GITHUB_CMD_SPEC_TEMP_DIR, "branch_test")
+      Dir.mkdir_p(temp_dir)
+      config_path = File.join(temp_dir, "reps.toml")
+
+      command = GithubCommand.new(config_path, "develop")
+      command.should_not be_nil
+    end
+
+    it "should create a command with subtree flag" do
+      temp_dir = File.join(GITHUB_CMD_SPEC_TEMP_DIR, "subtree_test")
+      Dir.mkdir_p(temp_dir)
+      config_path = File.join(temp_dir, "reps.toml")
+
+      command = GithubCommand.new(config_path, nil, true)
+      command.should_not be_nil
+    end
+  end
+
+  describe "GithubCommand execute" do
+    it "should print error when no org name is provided" do
+      temp_dir = File.join(GITHUB_CMD_SPEC_TEMP_DIR, "no_org_test")
+      Dir.mkdir_p(temp_dir)
+      config_path = File.join(temp_dir, "reps.toml")
+
+      command = GithubCommand.new(config_path)
+
+      # Execute with no org name - should not raise, just print error
+      command.execute(nil, nil, [] of String)
+
+      # The command should complete without error
+      true.should be_true
+    end
+
+    it "should print error for empty org name" do
+      temp_dir = File.join(GITHUB_CMD_SPEC_TEMP_DIR, "empty_org_test")
+      Dir.mkdir_p(temp_dir)
+      config_path = File.join(temp_dir, "reps.toml")
+
+      command = GithubCommand.new(config_path)
+
+      # Execute with empty org name - should not raise, just print error
+      command.execute(nil, "", [] of String)
+
+      # The command should complete without error
+      true.should be_true
+    end
+  end
+end
+
+describe "github command in command factory" do
+  it "should create GithubCommand from factory" do
+    command = CommandFactory.create_command("github", ".meta/reps.toml")
+    command.should_not be_nil
+    command.should be_a(GithubCommand)
+  end
+
+  it "should create GithubCommand with subtree flag" do
+    command = CommandFactory.create_command("github", ".meta/reps.toml", nil, true)
+    command.should_not be_nil
+    command.should be_a(GithubCommand)
+  end
+
+  it "should create GithubCommand with branch override" do
+    command = CommandFactory.create_command("github", ".meta/reps.toml", "develop", false)
+    command.should_not be_nil
+    command.should be_a(GithubCommand)
+  end
+end
+
+describe "github command string parsing" do
+  it "should parse 'github' as valid command" do
+    result = get_command_from_string("github")
+    result.should eq(:github)
+  end
+end

--- a/src/milka/command_factory.cr
+++ b/src/milka/command_factory.cr
@@ -5,7 +5,9 @@ require "./commands/push_command"
 require "./commands/scan_command"
 require "./commands/create_command"
 require "./commands/remote_command"
+{% if flag?(:github_plugin) %}
 require "./commands/github_command"
+{% end %}
 
 class CommandFactory
   def self.create_command(command_string : String, config_path : String, branch_override : String? = nil, use_subtree : Bool = false)
@@ -24,8 +26,10 @@ class CommandFactory
       CreateCommand.new(config_path, branch_override, use_subtree)
     when "remote"
       RemoteCommand.new(config_path, branch_override)
+    {% if flag?(:github_plugin) %}
     when "github"
       GithubCommand.new(config_path, branch_override, use_subtree)
+    {% end %}
     else
       nil
     end

--- a/src/milka/command_factory.cr
+++ b/src/milka/command_factory.cr
@@ -28,11 +28,9 @@ class CommandFactory
     when "remote"
       RemoteCommand.new(config_path, branch_override)
     when "issues"
-      IssuesCommand.new(config_path, branch_override)
-    {% if flag?(:github_plugin) %}
+      IssuesCommand.new(config_path, branch_override){% if flag?(:github_plugin) %}
     when "github"
-      GithubCommand.new(config_path, branch_override, use_subtree)
-    {% end %}
+      GithubCommand.new(config_path, branch_override, use_subtree){% end %}
     else
       nil
     end

--- a/src/milka/command_factory.cr
+++ b/src/milka/command_factory.cr
@@ -5,6 +5,7 @@ require "./commands/push_command"
 require "./commands/scan_command"
 require "./commands/create_command"
 require "./commands/remote_command"
+require "./commands/github_command"
 
 class CommandFactory
   def self.create_command(command_string : String, config_path : String, branch_override : String? = nil, use_subtree : Bool = false)
@@ -23,6 +24,8 @@ class CommandFactory
       CreateCommand.new(config_path, branch_override, use_subtree)
     when "remote"
       RemoteCommand.new(config_path, branch_override)
+    when "github"
+      GithubCommand.new(config_path, branch_override, use_subtree)
     else
       nil
     end

--- a/src/milka/command_factory.cr
+++ b/src/milka/command_factory.cr
@@ -28,10 +28,10 @@ class CommandFactory
     when "remote"
       RemoteCommand.new(config_path, branch_override)
     when "issues"
-      IssuesCommand.new(config_path, branch_override){% if flag?(:github_plugin) %}
-    when "github"
-      GithubCommand.new(config_path, branch_override, use_subtree){% end %}
-    else
+      IssuesCommand.new(config_path, branch_override)
+    {% if flag?(:github_plugin) %}when "github"
+      GithubCommand.new(config_path, branch_override, use_subtree)
+    {% end %}else
       nil
     end
   end

--- a/src/milka/command_factory.cr
+++ b/src/milka/command_factory.cr
@@ -12,6 +12,20 @@ require "./commands/github_command"
 
 class CommandFactory
   def self.create_command(command_string : String, config_path : String, branch_override : String? = nil, use_subtree : Bool = false)
+    # First try base commands
+    result = create_base_command(command_string, config_path, branch_override, use_subtree)
+    return result if result
+
+    # Then try plugin commands
+    {% if flag?(:github_plugin) %}
+    result = create_github_command(command_string, config_path, branch_override, use_subtree)
+    return result if result
+    {% end %}
+
+    nil
+  end
+
+  private def self.create_base_command(command_string : String, config_path : String, branch_override : String?, use_subtree : Bool)
     case command_string
     when "clone"
       CloneCommand.new(config_path, branch_override)
@@ -29,10 +43,19 @@ class CommandFactory
       RemoteCommand.new(config_path, branch_override)
     when "issues"
       IssuesCommand.new(config_path, branch_override)
-    {% if flag?(:github_plugin) %}when "github"
-      GithubCommand.new(config_path, branch_override, use_subtree)
-    {% end %}else
+    else
       nil
     end
   end
+
+  {% if flag?(:github_plugin) %}
+  private def self.create_github_command(command_string : String, config_path : String, branch_override : String?, use_subtree : Bool)
+    case command_string
+    when "github"
+      GithubCommand.new(config_path, branch_override, use_subtree)
+    else
+      nil
+    end
+  end
+  {% end %}
 end

--- a/src/milka/commands.cr
+++ b/src/milka/commands.cr
@@ -31,6 +31,8 @@ def get_command_from_string(command_string : String)
     :create
   when "remote"
     :remote
+  when "github"
+    :github
   when "help"
     :help
   else
@@ -108,9 +110,9 @@ def main
     (non_option_args[2].starts_with?("http://") || non_option_args[2].starts_with?("https://"))
   )
 
-  # Load configuration for commands that need it (not for scan, create, or remote commands)
+  # Load configuration for commands that need it (not for scan, create, remote, or github commands)
   # Also skip loading config if this is a URL clone operation
-  if command_string != "scan" && command_string != "init" && command_string != "create" && command_string != "remote" && !is_url_clone
+  if command_string != "scan" && command_string != "init" && command_string != "create" && command_string != "remote" && command_string != "github" && !is_url_clone
     begin
       config = ConfigManager.load_mise_config(config_path)
       Utils.print_info("Loaded #{config.repositories.size} repositories")
@@ -144,7 +146,7 @@ def main
       exit(1)
     end
 
-    if command_string == "scan" || command_string == "create" || command_string == "remote" || command_string == "clone"
+    if command_string == "scan" || command_string == "create" || command_string == "remote" || command_string == "clone" || command_string == "github"
       command.execute(repositories, repo_name, additional_args)
     else
       command.execute(repositories, repo_name)

--- a/src/milka/commands.cr
+++ b/src/milka/commands.cr
@@ -32,10 +32,10 @@ def get_command_from_string(command_string : String)
   when "remote"
     :remote
   when "issues"
-    :issues{% if flag?(:github_plugin) %}
-  when "github"
-    :github{% end %}
-  when "help"
+    :issues
+  {% if flag?(:github_plugin) %}when "github"
+    :github
+  {% end %}when "help"
     :help
   else
     nil

--- a/src/milka/commands.cr
+++ b/src/milka/commands.cr
@@ -121,10 +121,9 @@ def main
   # Load configuration for commands that need it (not for scan, create, remote, issues, or github commands)
   # Also skip loading config if this is a URL clone operation
   # Issues and github commands can work without config if a URL/org-name is provided
-  {% if flag?(:github_plugin) %}
-  skip_config_load = command_string == "scan" || command_string == "init" || command_string == "create" || command_string == "remote" || command_string == "issues" || command_string == "github" || is_url_clone
-  {% else %}
   skip_config_load = command_string == "scan" || command_string == "init" || command_string == "create" || command_string == "remote" || command_string == "issues" || is_url_clone
+  {% if flag?(:github_plugin) %}
+  skip_config_load = skip_config_load || command_string == "github"
   {% end %}
   if !skip_config_load
     begin
@@ -174,10 +173,9 @@ def main
       exit(1)
     end
 
-    {% if flag?(:github_plugin) %}
-    needs_additional_args = command_string == "scan" || command_string == "create" || command_string == "remote" || command_string == "clone" || command_string == "issues" || command_string == "github"
-    {% else %}
     needs_additional_args = command_string == "scan" || command_string == "create" || command_string == "remote" || command_string == "clone" || command_string == "issues"
+    {% if flag?(:github_plugin) %}
+    needs_additional_args = needs_additional_args || command_string == "github"
     {% end %}
     if needs_additional_args
       command.execute(repositories, repo_name, additional_args)

--- a/src/milka/commands.cr
+++ b/src/milka/commands.cr
@@ -31,8 +31,10 @@ def get_command_from_string(command_string : String)
     :create
   when "remote"
     :remote
+  {% if flag?(:github_plugin) %}
   when "github"
     :github
+  {% end %}
   when "help"
     :help
   else
@@ -110,9 +112,14 @@ def main
     (non_option_args[2].starts_with?("http://") || non_option_args[2].starts_with?("https://"))
   )
 
-  # Load configuration for commands that need it (not for scan, create, remote, or github commands)
+  # Load configuration for commands that need it (not for scan, create, remote commands)
   # Also skip loading config if this is a URL clone operation
-  if command_string != "scan" && command_string != "init" && command_string != "create" && command_string != "remote" && command_string != "github" && !is_url_clone
+  {% if flag?(:github_plugin) %}
+  skip_config_load = command_string == "scan" || command_string == "init" || command_string == "create" || command_string == "remote" || command_string == "github" || is_url_clone
+  {% else %}
+  skip_config_load = command_string == "scan" || command_string == "init" || command_string == "create" || command_string == "remote" || is_url_clone
+  {% end %}
+  if !skip_config_load
     begin
       config = ConfigManager.load_mise_config(config_path)
       Utils.print_info("Loaded #{config.repositories.size} repositories")
@@ -146,7 +153,12 @@ def main
       exit(1)
     end
 
-    if command_string == "scan" || command_string == "create" || command_string == "remote" || command_string == "clone" || command_string == "github"
+    {% if flag?(:github_plugin) %}
+    needs_additional_args = command_string == "scan" || command_string == "create" || command_string == "remote" || command_string == "clone" || command_string == "github"
+    {% else %}
+    needs_additional_args = command_string == "scan" || command_string == "create" || command_string == "remote" || command_string == "clone"
+    {% end %}
+    if needs_additional_args
       command.execute(repositories, repo_name, additional_args)
     else
       command.execute(repositories, repo_name)

--- a/src/milka/commands.cr
+++ b/src/milka/commands.cr
@@ -32,11 +32,9 @@ def get_command_from_string(command_string : String)
   when "remote"
     :remote
   when "issues"
-    :issues
-  {% if flag?(:github_plugin) %}
+    :issues{% if flag?(:github_plugin) %}
   when "github"
-    :github
-  {% end %}
+    :github{% end %}
   when "help"
     :help
   else

--- a/src/milka/commands.cr
+++ b/src/milka/commands.cr
@@ -16,6 +16,14 @@ def init_config(config_path : String)
 end
 
 def get_command_from_string(command_string : String)
+  # Check plugin commands first
+  {% if flag?(:github_plugin) %}
+  if command_string == "github"
+    return :github
+  end
+  {% end %}
+
+  # Then check base commands
   case command_string
   when "clone"
     :clone
@@ -33,9 +41,7 @@ def get_command_from_string(command_string : String)
     :remote
   when "issues"
     :issues
-  {% if flag?(:github_plugin) %}when "github"
-    :github
-  {% end %}when "help"
+  when "help"
     :help
   else
     nil

--- a/src/milka/commands/github_command.cr
+++ b/src/milka/commands/github_command.cr
@@ -1,0 +1,195 @@
+require "../../milka/types/repository_info"
+require "../../milka/types/git_error"
+require "../utils"
+require "../config_manager"
+require "http/client"
+require "json"
+
+class GithubCommand
+  def initialize(@config_path : String, @branch_override : String? = nil, @use_subtree : Bool = false)
+  end
+
+  def execute(repositories : Array(RepositoryInfo)? = nil, repo_name : String? = nil, additional_args : Array(String) = [] of String)
+    # repo_name is the organization or user name
+    org_name = repo_name
+
+    if org_name.nil? || org_name.empty?
+      Utils.print_error("Error: Organization or username is required")
+      Utils.print_info("Usage: milka github <org-name> [--clone]")
+      Utils.print_info("       milka github <org-name> --clone   # Also clone the repositories")
+      return
+    end
+
+    # Check if we should also clone the repos
+    should_clone = additional_args.includes?("--clone")
+
+    Utils.print_info("Fetching repositories for organization/user: #{org_name}")
+
+    begin
+      repos = fetch_github_repos(org_name)
+
+      if repos.empty?
+        Utils.print_warning("No repositories found for: #{org_name}")
+        return
+      end
+
+      Utils.print_success("Found #{repos.size} repositories")
+
+      added_count = 0
+      cloned_count = 0
+
+      repos.each do |repo|
+        repo_info = parse_repo_info(repo)
+        next if repo_info.nil?
+
+        # Add to config
+        source = @use_subtree ? "git+subtree" : "git"
+        if ConfigManager.repo_exists_in_config(@config_path, repo_info[:name])
+          Utils.print_info("  #{repo_info[:name]} already in config, skipping...")
+        else
+          ConfigManager.add_git_repo_to_config(@config_path, repo_info[:name], repo_info[:url], repo_info[:branch], source)
+          Utils.print_success("  Added #{repo_info[:name]} to config")
+          added_count += 1
+        end
+
+        # Clone if requested
+        if should_clone && !Dir.exists?(repo_info[:name])
+          Utils.print_info("  Cloning #{repo_info[:name]}...")
+          if clone_repository(repo_info[:url], repo_info[:name], repo_info[:branch])
+            Utils.print_success("  Cloned #{repo_info[:name]}")
+            cloned_count += 1
+          else
+            Utils.print_error("  Failed to clone #{repo_info[:name]}")
+          end
+        elsif should_clone && Dir.exists?(repo_info[:name])
+          Utils.print_info("  #{repo_info[:name]} already exists locally, skipping clone...")
+        end
+      end
+
+      Utils.print_success("GitHub scan completed!")
+      Utils.print_info("  Added #{added_count} repositories to #{@config_path}")
+      if should_clone
+        Utils.print_info("  Cloned #{cloned_count} repositories")
+      end
+    rescue e : Exception
+      Utils.print_error("Error fetching repositories: #{e.message}")
+    end
+  end
+
+  private def fetch_github_repos(org_name : String) : Array(JSON::Any)
+    all_repos = [] of JSON::Any
+    page = 1
+    per_page = 100
+
+    # First try as organization
+    loop do
+      url = "https://api.github.com/orgs/#{org_name}/repos?page=#{page}&per_page=#{per_page}"
+      response = make_github_request(url)
+
+      if response.nil?
+        # Try as user instead
+        Utils.print_info("Not found as organization, trying as user...")
+        return fetch_user_repos(org_name)
+      end
+
+      repos = JSON.parse(response)
+      break if !repos.as_a? || repos.as_a.empty?
+
+      all_repos.concat(repos.as_a)
+
+      # If we got fewer than per_page, we've reached the end
+      break if repos.as_a.size < per_page
+
+      page += 1
+    end
+
+    all_repos
+  end
+
+  private def fetch_user_repos(username : String) : Array(JSON::Any)
+    all_repos = [] of JSON::Any
+    page = 1
+    per_page = 100
+
+    loop do
+      url = "https://api.github.com/users/#{username}/repos?page=#{page}&per_page=#{per_page}"
+      response = make_github_request(url)
+
+      if response.nil?
+        Utils.print_error("Could not fetch repositories for: #{username}")
+        return [] of JSON::Any
+      end
+
+      repos = JSON.parse(response)
+      break if !repos.as_a? || repos.as_a.empty?
+
+      all_repos.concat(repos.as_a)
+
+      # If we got fewer than per_page, we've reached the end
+      break if repos.as_a.size < per_page
+
+      page += 1
+    end
+
+    all_repos
+  end
+
+  private def make_github_request(url : String) : String?
+    headers = HTTP::Headers.new
+    headers["Accept"] = "application/vnd.github.v3+json"
+    headers["User-Agent"] = "Milka-CLI"
+
+    # Check for GitHub token in environment
+    if token = ENV["GITHUB_TOKEN"]?
+      headers["Authorization"] = "token #{token}"
+    elsif token = ENV["GH_TOKEN"]?
+      headers["Authorization"] = "token #{token}"
+    end
+
+    response = HTTP::Client.get(url, headers: headers)
+
+    case response.status_code
+    when 200
+      response.body
+    when 404
+      nil
+    when 403
+      Utils.print_warning("Rate limit may be exceeded. Set GITHUB_TOKEN environment variable for higher limits.")
+      nil
+    else
+      Utils.print_error("GitHub API returned status: #{response.status_code}")
+      nil
+    end
+  end
+
+  private def parse_repo_info(repo : JSON::Any) : NamedTuple(name: String, url: String, branch: String)?
+    begin
+      name = repo["name"]?.try(&.as_s)
+      clone_url = repo["clone_url"]?.try(&.as_s)
+      default_branch = repo["default_branch"]?.try(&.as_s) || "main"
+
+      return nil if name.nil? || clone_url.nil?
+
+      # Use branch override if provided
+      branch = @branch_override || default_branch
+
+      {name: name, url: clone_url, branch: branch}
+    rescue
+      nil
+    end
+  end
+
+  private def clone_repository(url : String, dir : String, branch : String) : Bool
+    stdout_builder = String::Builder.new
+    stderr_builder = String::Builder.new
+
+    result = Process.run(
+      "git",
+      ["clone", "--branch", branch, url, dir],
+      output: stdout_builder,
+      error: stderr_builder
+    )
+
+    result.success?
+  end
+end

--- a/src/milka/utils.cr
+++ b/src/milka/utils.cr
@@ -29,6 +29,7 @@ module Utils
   end
 
   def self.print_usage
+    {% if flag?(:github_plugin) %}
     puts <<-USAGE
     Milka - A command-line tool for managing multiple git repositories
 
@@ -71,6 +72,49 @@ module Utils
       milka --config /path/to/reps.toml clone
       milka --config /path/to/reps.toml --branch feature-branch clone my-repo
     USAGE
+    {% else %}
+    puts <<-USAGE
+    Milka - A command-line tool for managing multiple git repositories
+
+    Usage: milka <command> [repo-name] [options]
+
+    Commands:
+      clone [repo-name]    Clone a repository or all repositories (if no repo-name provided)
+      fetch [repo-name]    Fetch updates for a repository or all repositories (if no repo-name provided)
+      pull [repo-name]     Pull latest changes for a repository or all repositories (if no repo-name provided)
+      push [repo-name]     Push changes for all repositories
+      scan                 Scan for git repositories in the current directory and add them to reps.toml
+      create <repo-name> [remote-url]   Create a new git repository and optionally set its remote
+      remote <repo-name> <remote-url>   Add a remote to a local git repository
+      help                 Show this help message
+
+    Options:
+      --config <path>      Path to reps.toml configuration file (default: ./.meta/reps.toml)
+      --branch <branch>    Specify branch (default: from config or main)
+      --subtree            Use git subtree operations (for scan, create commands)
+
+    Examples:
+      milka clone                    Clone all repositories from reps.toml
+      milka clone my-repo            Clone specific repository
+      milka fetch                    Fetch updates for all repositories
+      milka fetch my-repo            Fetch updates for specific repository
+      milka pull                     Pull latest changes for all repositories
+      milka pull my-repo             Pull latest changes for specific repository
+      milka push                     Push changes for all repositories
+      milka push my-repo             Push changes for specific repository
+      milka scan                     Scan current directory for git repos and add to reps.toml
+      milka scan --subtree           Scan and add repos with subtree
+      milka create my-repo           Create a new git repository
+      milka create my-repo https://example.com/user/repo.git    Create a new git repository with remote
+      milka create my-subtree --subtree  Create a subtree git repository in existing directory
+      milka remote my-repo https://example.com/user/repo.git    Add remote to a local git repository
+      milka --config /path/to/reps.toml clone
+      milka --config /path/to/reps.toml --branch feature-branch clone my-repo
+
+    Note: Build with `-Dgithub_plugin` flag to enable the github command for scanning
+    GitHub organizations and users (requires shards build milka-github -Dgithub_plugin).
+    USAGE
+    {% end %}
   end
 
   def self.find_repository_in(repositories : Array(RepositoryInfo), named name : String)

--- a/src/milka/utils.cr
+++ b/src/milka/utils.cr
@@ -42,11 +42,13 @@ module Utils
       scan                 Scan for git repositories in the current directory and add them to reps.toml
       create <repo-name> [remote-url]   Create a new git repository and optionally set its remote
       remote <repo-name> <remote-url>   Add a remote to a local git repository
+      github <org-name> [--clone]       Scan GitHub org/user repos and add them to config (optionally clone)
       help                 Show this help message
 
     Options:
       --config <path>      Path to reps.toml configuration file (default: ./.meta/reps.toml)
       --branch <branch>    Specify branch (default: from config or main)
+      --subtree            Use git subtree operations (for scan, create, github commands)
 
     Examples:
       milka clone                    Clone all repositories from reps.toml
@@ -59,6 +61,9 @@ module Utils
       milka push my-repo             Push changes for specific repository
       milka scan                     Scan current directory for git repos and add to reps.toml
       milka scan --subtree           Scan and add repos with subtree
+      milka github myorg             Scan GitHub org 'myorg' and add repos to config
+      milka github myorg --clone     Scan GitHub org 'myorg', add to config, and clone all repos
+      milka github myuser --subtree  Scan GitHub user 'myuser' and add repos with subtree source
       milka create my-repo           Create a new git repository
       milka create my-repo https://example.com/user/repo.git    Create a new git repository with remote
       milka create my-subtree --subtree  Create a subtree git repository in existing directory


### PR DESCRIPTION
## Summary

This PR implements the feature requested in #1 - the ability to scan GitHub repositories of an organization and download them. **As per the maintainer's feedback, the github command is now implemented as an optional plugin** that can be built separately using the `-Dgithub_plugin` compile-time flag.

### Plugin Architecture

The github command is now an **optional build-time plugin** rather than part of the default build:

- **Default build** (`shards build`): Lightweight core milka without github command
- **Plugin build** (`shards build milka-github -Dgithub_plugin`): Full version with github command

### Features of the GitHub Plugin

- **Scan and clone org repos**: `milka-github github <org-name>` adds all repos to config
- **Optional cloning**: Use `--clone` flag to also clone the repositories
- **Subtree support**: Use `--subtree` flag to set source as `git+subtree`
- **Automatic pagination**: Handles organizations with many repositories
- **GitHub API authentication**: Support for `GITHUB_TOKEN` and `GH_TOKEN` environment variables
- **User fallback**: Automatically tries as user if organization not found

### Changes

- `src/milka/command_factory.cr` - Conditional require and command creation
- `src/milka/commands.cr` - Conditional command parsing and execution
- `src/milka/utils.cr` - Conditional help text display
- `src/milka/commands/github_command.cr` - The github command implementation
- `shard.yml` - Added `milka-github` target, version bump to 2025.11.8
- `spec/github/github_command_spec.cr` - Tests wrapped in conditional compilation
- `.github/workflows/test.yml` - Tests both default and plugin builds
- `.github/workflows/release.yml` - Releases both default and plugin binaries
- `.github/workflows/static-release.yml` - Static builds for both versions
- `.meta/packaging/static-builds/Containerfile.github` - Container for plugin static build
- `README.md` - Updated documentation for plugin-based architecture

### Usage Examples

```bash
# Build the default version (without github command)
shards build

# Build the plugin version (with github command)
shards build milka-github -Dgithub_plugin

# Using the plugin
milka-github github myorg                    # Scan org and add repos to config
milka-github github myorg --clone            # Scan and clone all repositories
GITHUB_TOKEN=your_token milka-github github private-org --clone  # With authentication
```

## Test plan

- [x] Default build compiles without github command
- [x] Plugin build compiles with github command
- [x] Default milka help doesn't show github command
- [x] Plugin milka-github help shows github command
- [x] All existing tests pass with default build
- [x] GitHub command tests pass with plugin build
- [x] CI runs tests for both build configurations

Fixes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)