### PR TITLE
feat: add issues download command for GitHub and Forgejo

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: https://github.com/kogeletey/milka/issues/3
-Your prepared branch: issue-3-3986b40d02e6
-Your prepared working directory: /tmp/gh-issue-solver-1767113896656
-Your forked repository: konard/kogeletey-milka
-Original repository (upstream): kogeletey/milka
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+Issue to solve: https://github.com/kogeletey/milka/issues/3
+Your prepared branch: issue-3-3986b40d02e6
+Your prepared working directory: /tmp/gh-issue-solver-1767113896656
+Your forked repository: konard/kogeletey-milka
+Original repository (upstream): kogeletey/milka
+
+Proceed.

--- a/spec/issues/comment_info_spec.cr
+++ b/spec/issues/comment_info_spec.cr
@@ -1,0 +1,145 @@
+require "spec"
+require "../../src/milka/types/comment_info"
+
+describe "CommentInfo" do
+  describe "initialization" do
+    it "creates a comment with all fields" do
+      comment = CommentInfo.new(
+        id: 123_i64,
+        body: "This is a comment",
+        author: "testuser",
+        author_url: "https://github.com/testuser",
+        created_at: "2024-01-15T10:00:00Z",
+        updated_at: "2024-01-16T10:00:00Z",
+        html_url: "https://github.com/owner/repo/issues/42#issuecomment-123"
+      )
+
+      comment.id.should eq(123_i64)
+      comment.body.should eq("This is a comment")
+      comment.author.should eq("testuser")
+      comment.author_url.should eq("https://github.com/testuser")
+      comment.created_at.should eq("2024-01-15T10:00:00Z")
+      comment.updated_at.should eq("2024-01-16T10:00:00Z")
+      comment.html_url.should eq("https://github.com/owner/repo/issues/42#issuecomment-123")
+    end
+
+    it "creates a comment with minimal fields" do
+      comment = CommentInfo.new(id: 1_i64)
+
+      comment.id.should eq(1_i64)
+      comment.body.should eq("")
+      comment.author.should eq("")
+      comment.author_url.should eq("")
+    end
+  end
+
+  describe "#to_org" do
+    it "formats comment with author URL as org-mode link" do
+      comment = CommentInfo.new(
+        id: 123_i64,
+        body: "Comment content",
+        author: "testuser",
+        author_url: "https://github.com/testuser"
+      )
+
+      org = comment.to_org
+
+      org.should contain(":PROPERTIES:")
+      org.should contain(":author: [[https://github.com/testuser][testuser]]")
+      org.should contain(":id: 123")
+      org.should contain(":END:")
+      org.should contain("Comment content")
+    end
+
+    it "formats comment with plain author when no URL" do
+      comment = CommentInfo.new(
+        id: 456_i64,
+        body: "Comment body",
+        author: "plain_user"
+      )
+
+      org = comment.to_org
+
+      org.should contain(":author: plain_user")
+      org.should_not contain("[[")
+    end
+  end
+
+  describe "#to_md" do
+    it "formats comment as HTML element with author URL" do
+      comment = CommentInfo.new(
+        id: 123_i64,
+        body: "Comment content",
+        author: "testuser",
+        author_url: "https://github.com/testuser"
+      )
+
+      md = comment.to_md
+
+      md.should contain("<comments-comment")
+      md.should contain("author=\"https://github.com/testuser\"")
+      md.should contain("id=\"123\"")
+      md.should contain("Comment content")
+      md.should contain("</comments-comment>")
+    end
+
+    it "uses author name when no URL available" do
+      comment = CommentInfo.new(
+        id: 456_i64,
+        body: "Body",
+        author: "plain_user"
+      )
+
+      md = comment.to_md
+
+      md.should contain("author=\"plain_user\"")
+    end
+  end
+
+  describe "#to_json_ld" do
+    it "formats comment as ForgeFed Note" do
+      comment = CommentInfo.new(
+        id: 123_i64,
+        body: "Comment text",
+        author: "testuser",
+        author_url: "https://github.com/testuser",
+        created_at: "2024-01-15T10:00:00Z",
+        html_url: "https://github.com/owner/repo/issues/42#issuecomment-123"
+      )
+
+      json = comment.to_json_ld
+
+      json.should contain("\"type\": \"Note\"")
+      json.should contain("\"id\": 123")
+      json.should contain("\"attributedTo\": \"https://github.com/testuser\"")
+      json.should contain("\"content\": \"Comment text\"")
+      json.should contain("\"mediaType\": \"text/markdown\"")
+      json.should contain("\"published\": \"2024-01-15T10:00:00Z\"")
+      json.should contain("\"url\": \"https://github.com/owner/repo/issues/42#issuecomment-123\"")
+    end
+
+    it "uses author name when no URL available" do
+      comment = CommentInfo.new(
+        id: 456_i64,
+        body: "Body",
+        author: "plain_user"
+      )
+
+      json = comment.to_json_ld
+
+      json.should contain("\"attributedTo\": \"plain_user\"")
+    end
+
+    it "escapes special characters in JSON" do
+      comment = CommentInfo.new(
+        id: 1_i64,
+        body: "Comment with \"quotes\" and\nnewlines"
+      )
+
+      json = comment.to_json_ld
+
+      json.should contain("\\\"quotes\\\"")
+      json.should contain("\\n")
+    end
+  end
+end

--- a/spec/issues/issue_info_spec.cr
+++ b/spec/issues/issue_info_spec.cr
@@ -1,0 +1,121 @@
+require "spec"
+require "../../src/milka/types/issue_info"
+
+describe "IssueInfo" do
+  describe "initialization" do
+    it "creates an issue with all fields" do
+      issue = IssueInfo.new(
+        number: 42,
+        title: "Test Issue",
+        body: "This is the body",
+        state: "open",
+        created_at: "2024-01-15T10:00:00Z",
+        updated_at: "2024-01-16T10:00:00Z",
+        author: "testuser",
+        labels: ["bug", "help wanted"],
+        html_url: "https://github.com/owner/repo/issues/42"
+      )
+
+      issue.number.should eq(42)
+      issue.title.should eq("Test Issue")
+      issue.body.should eq("This is the body")
+      issue.state.should eq("open")
+      issue.created_at.should eq("2024-01-15T10:00:00Z")
+      issue.updated_at.should eq("2024-01-16T10:00:00Z")
+      issue.author.should eq("testuser")
+      issue.labels.should eq(["bug", "help wanted"])
+      issue.html_url.should eq("https://github.com/owner/repo/issues/42")
+    end
+
+    it "creates an issue with minimal fields" do
+      issue = IssueInfo.new(number: 1, title: "Minimal Issue")
+
+      issue.number.should eq(1)
+      issue.title.should eq("Minimal Issue")
+      issue.body.should eq("")
+      issue.state.should eq("open")
+      issue.labels.should be_empty
+    end
+  end
+
+  describe "#to_org" do
+    it "formats issue as org file" do
+      issue = IssueInfo.new(
+        number: 42,
+        title: "Test Issue",
+        body: "Issue body content",
+        state: "open",
+        created_at: "2024-01-15T10:00:00Z",
+        author: "testuser",
+        labels: ["bug"],
+        html_url: "https://github.com/owner/repo/issues/42"
+      )
+
+      org = issue.to_org
+
+      org.should contain("#+title: Test Issue")
+      org.should contain("#+id: 42")
+      org.should contain("#+date: 2024-01-15T10:00:00Z")
+      org.should contain("#+state: open")
+      org.should contain("#+author: testuser")
+      org.should contain("#+url: https://github.com/owner/repo/issues/42")
+      org.should contain("#+labels: bug")
+      org.should contain("Issue body content")
+    end
+
+    it "omits url and labels if empty" do
+      issue = IssueInfo.new(
+        number: 1,
+        title: "Simple Issue",
+        body: "Body",
+        state: "closed"
+      )
+
+      org = issue.to_org
+
+      org.should contain("#+title: Simple Issue")
+      org.should_not contain("#+url:")
+      org.should_not contain("#+labels:")
+    end
+  end
+
+  describe "#to_md" do
+    it "formats issue as markdown file with YAML frontmatter" do
+      issue = IssueInfo.new(
+        number: 42,
+        title: "Test Issue",
+        body: "Issue body content",
+        state: "open",
+        created_at: "2024-01-15T10:00:00Z",
+        author: "testuser",
+        labels: ["bug", "feature"],
+        html_url: "https://github.com/owner/repo/issues/42"
+      )
+
+      md = issue.to_md
+
+      md.should contain("---")
+      md.should contain("title: \"Test Issue\"")
+      md.should contain("id: 42")
+      md.should contain("date: 2024-01-15T10:00:00Z")
+      md.should contain("state: open")
+      md.should contain("author: testuser")
+      md.should contain("url: https://github.com/owner/repo/issues/42")
+      md.should contain("labels: [\"bug\", \"feature\"]")
+      md.should contain("# Test Issue")
+      md.should contain("Issue body content")
+    end
+
+    it "escapes quotes in title for YAML" do
+      issue = IssueInfo.new(
+        number: 1,
+        title: "Issue with \"quotes\" in title",
+        body: "Body"
+      )
+
+      md = issue.to_md
+
+      md.should contain("title: \"Issue with \\\"quotes\\\" in title\"")
+    end
+  end
+end

--- a/spec/issues/issue_info_spec.cr
+++ b/spec/issues/issue_info_spec.cr
@@ -1,5 +1,6 @@
 require "spec"
 require "../../src/milka/types/issue_info"
+require "../../src/milka/types/comment_info"
 
 describe "IssueInfo" do
   describe "initialization" do
@@ -35,6 +36,24 @@ describe "IssueInfo" do
       issue.body.should eq("")
       issue.state.should eq("open")
       issue.labels.should be_empty
+      issue.comments.should be_empty
+    end
+
+    it "creates an issue with comments" do
+      comment = CommentInfo.new(
+        id: 123_i64,
+        body: "Test comment",
+        author: "commenter"
+      )
+      issue = IssueInfo.new(
+        number: 42,
+        title: "Issue with comments",
+        body: "Body",
+        comments: [comment]
+      )
+
+      issue.comments.size.should eq(1)
+      issue.comments[0].body.should eq("Test comment")
     end
   end
 
@@ -77,6 +96,42 @@ describe "IssueInfo" do
       org.should_not contain("#+url:")
       org.should_not contain("#+labels:")
     end
+
+    it "includes comments section when comments exist" do
+      comment = CommentInfo.new(
+        id: 123_i64,
+        body: "This is a comment",
+        author: "commenter",
+        author_url: "https://github.com/commenter"
+      )
+      issue = IssueInfo.new(
+        number: 1,
+        title: "Issue with comments",
+        body: "Body",
+        comments: [comment]
+      )
+
+      org = issue.to_org
+
+      org.should contain("#+begin_comments")
+      org.should contain("#+end_comments")
+      org.should contain(":author: [[https://github.com/commenter][commenter]]")
+      org.should contain(":id: 123")
+      org.should contain("This is a comment")
+    end
+
+    it "omits comments section when no comments" do
+      issue = IssueInfo.new(
+        number: 1,
+        title: "No comments",
+        body: "Body"
+      )
+
+      org = issue.to_org
+
+      org.should_not contain("#+begin_comments")
+      org.should_not contain("#+end_comments")
+    end
   end
 
   describe "#to_md" do
@@ -102,8 +157,22 @@ describe "IssueInfo" do
       md.should contain("author: testuser")
       md.should contain("url: https://github.com/owner/repo/issues/42")
       md.should contain("labels: [\"bug\", \"feature\"]")
-      md.should contain("# Test Issue")
       md.should contain("Issue body content")
+    end
+
+    it "does not duplicate title as heading" do
+      issue = IssueInfo.new(
+        number: 42,
+        title: "Test Issue",
+        body: "Issue body content"
+      )
+
+      md = issue.to_md
+
+      # Title should be in frontmatter
+      md.should contain("title: \"Test Issue\"")
+      # But NOT as a markdown heading
+      md.should_not contain("# Test Issue")
     end
 
     it "escapes quotes in title for YAML" do
@@ -116,6 +185,125 @@ describe "IssueInfo" do
       md = issue.to_md
 
       md.should contain("title: \"Issue with \\\"quotes\\\" in title\"")
+    end
+
+    it "includes comments section when comments exist" do
+      comment = CommentInfo.new(
+        id: 123_i64,
+        body: "This is a comment",
+        author: "commenter",
+        author_url: "https://github.com/commenter"
+      )
+      issue = IssueInfo.new(
+        number: 1,
+        title: "Issue with comments",
+        body: "Body",
+        comments: [comment]
+      )
+
+      md = issue.to_md
+
+      md.should contain("<begin-comments>")
+      md.should contain("</begin-comments>")
+      md.should contain("<comments-comment")
+      md.should contain("author=\"https://github.com/commenter\"")
+      md.should contain("id=\"123\"")
+      md.should contain("This is a comment")
+    end
+  end
+
+  describe "#to_json_ld" do
+    it "formats issue as JSON-LD with ForgeFed Ticket type" do
+      issue = IssueInfo.new(
+        number: 42,
+        title: "Test Issue",
+        body: "Issue body content",
+        state: "open",
+        created_at: "2024-01-15T10:00:00Z",
+        updated_at: "2024-01-16T10:00:00Z",
+        author: "testuser",
+        author_url: "https://github.com/testuser",
+        labels: ["bug"],
+        html_url: "https://github.com/owner/repo/issues/42",
+        context_url: "https://github.com/owner/repo"
+      )
+
+      json = issue.to_json_ld
+
+      json.should contain("\"@context\":")
+      json.should contain("https://www.w3.org/ns/activitystreams")
+      json.should contain("https://forgefed.org/ns")
+      json.should contain("\"type\": \"Ticket\"")
+      json.should contain("\"summary\": \"Test Issue\"")
+      json.should contain("\"content\": \"Issue body content\"")
+      json.should contain("\"mediaType\": \"text/markdown\"")
+      json.should contain("\"published\": \"2024-01-15T10:00:00Z\"")
+      json.should contain("\"isResolved\": false")
+      json.should contain("\"attributedTo\": \"https://github.com/testuser\"")
+    end
+
+    it "sets isResolved to true for closed issues" do
+      issue = IssueInfo.new(
+        number: 1,
+        title: "Closed Issue",
+        body: "Body",
+        state: "closed"
+      )
+
+      json = issue.to_json_ld
+
+      json.should contain("\"isResolved\": true")
+    end
+
+    it "includes labels as tags" do
+      issue = IssueInfo.new(
+        number: 1,
+        title: "Tagged Issue",
+        body: "Body",
+        labels: ["bug", "enhancement"]
+      )
+
+      json = issue.to_json_ld
+
+      json.should contain("\"tag\":")
+      json.should contain("\"type\": \"Label\"")
+      json.should contain("\"name\": \"bug\"")
+      json.should contain("\"name\": \"enhancement\"")
+    end
+
+    it "includes comments as replies" do
+      comment = CommentInfo.new(
+        id: 123_i64,
+        body: "Comment text",
+        author: "commenter",
+        created_at: "2024-01-15T11:00:00Z"
+      )
+      issue = IssueInfo.new(
+        number: 1,
+        title: "Issue with comments",
+        body: "Body",
+        comments: [comment]
+      )
+
+      json = issue.to_json_ld
+
+      json.should contain("\"replies\":")
+      json.should contain("\"type\": \"Note\"")
+      json.should contain("\"content\": \"Comment text\"")
+    end
+
+    it "escapes special characters in JSON" do
+      issue = IssueInfo.new(
+        number: 1,
+        title: "Issue with \"quotes\" and\nnewlines",
+        body: "Body with\ttabs"
+      )
+
+      json = issue.to_json_ld
+
+      json.should contain("\\\"quotes\\\"")
+      json.should contain("\\n")
+      json.should contain("\\t")
     end
   end
 end

--- a/spec/issues/issue_provider_spec.cr
+++ b/spec/issues/issue_provider_spec.cr
@@ -1,0 +1,68 @@
+require "spec"
+require "../../src/milka/providers/issue_provider"
+
+describe "IssueProvider" do
+  describe ".parse_repo_url" do
+    it "parses GitHub HTTPS URL" do
+      result = IssueProvider.parse_repo_url("https://github.com/owner/repo")
+      result.should eq({"owner", "repo"})
+    end
+
+    it "parses GitHub HTTPS URL with .git suffix" do
+      result = IssueProvider.parse_repo_url("https://github.com/owner/repo.git")
+      result.should eq({"owner", "repo"})
+    end
+
+    it "parses GitHub SSH URL" do
+      result = IssueProvider.parse_repo_url("git@github.com:owner/repo.git")
+      result.should eq({"owner", "repo"})
+    end
+
+    it "parses Codeberg HTTPS URL" do
+      result = IssueProvider.parse_repo_url("https://codeberg.org/user/project")
+      result.should eq({"user", "project"})
+    end
+
+    it "parses generic Gitea instance URL" do
+      result = IssueProvider.parse_repo_url("https://gitea.example.com/org/project")
+      result.should eq({"org", "project"})
+    end
+
+    it "returns nil for invalid URL" do
+      result = IssueProvider.parse_repo_url("not-a-valid-url")
+      result.should be_nil
+    end
+  end
+
+  describe ".detect_provider_type" do
+    it "detects GitHub" do
+      IssueProvider.detect_provider_type("https://github.com/owner/repo").should eq("github")
+    end
+
+    it "detects Forgejo for Codeberg" do
+      IssueProvider.detect_provider_type("https://codeberg.org/user/repo").should eq("forgejo")
+    end
+
+    it "detects Forgejo for gitea in URL" do
+      IssueProvider.detect_provider_type("https://gitea.example.com/user/repo").should eq("forgejo")
+    end
+
+    it "defaults to forgejo for unknown hosts" do
+      IssueProvider.detect_provider_type("https://git.example.com/user/repo").should eq("forgejo")
+    end
+  end
+
+  describe ".extract_base_url" do
+    it "extracts base URL from HTTPS" do
+      IssueProvider.extract_base_url("https://github.com/owner/repo").should eq("https://github.com")
+    end
+
+    it "extracts base URL from HTTP" do
+      IssueProvider.extract_base_url("http://gitea.local:3000/user/repo").should eq("http://gitea.local:3000")
+    end
+
+    it "extracts base URL from SSH" do
+      IssueProvider.extract_base_url("git@github.com:owner/repo.git").should eq("https://github.com")
+    end
+  end
+end

--- a/spec/issues/issues_command_spec.cr
+++ b/spec/issues/issues_command_spec.cr
@@ -1,0 +1,85 @@
+require "spec"
+require "file_utils"
+require "../../src/milka/types/repository_info"
+require "../../src/milka/types/issue_info"
+require "../../src/milka/types/git_error"
+require "../../src/milka/commands/issues_command"
+
+# Create temporary directory for test isolation
+ISSUES_COMMAND_SPEC_TEMP_DIR = File.join(Dir.tempdir, "milka_issues_command_spec_#{Time.local.to_unix}")
+
+describe "IssuesCommand" do
+  before_all do
+    Dir.mkdir_p(ISSUES_COMMAND_SPEC_TEMP_DIR)
+  end
+
+  after_all do
+    if Dir.exists?(ISSUES_COMMAND_SPEC_TEMP_DIR)
+      FileUtils.rm_rf(ISSUES_COMMAND_SPEC_TEMP_DIR)
+    end
+  end
+
+  describe "initialization" do
+    it "creates command with default values" do
+      cmd = IssuesCommand.new(".meta/reps.toml")
+      cmd.output_format.should eq("org")
+      cmd.output_dir.should eq(".meta/issues")
+      cmd.state_filter.should eq("all")
+    end
+
+    it "creates command with custom values" do
+      cmd = IssuesCommand.new(
+        ".meta/reps.toml",
+        branch_override: "main",
+        output_format: "md",
+        output_dir: "/custom/path",
+        state_filter: "open"
+      )
+      cmd.output_format.should eq("md")
+      cmd.output_dir.should eq("/custom/path")
+      cmd.state_filter.should eq("open")
+    end
+  end
+
+  describe "argument parsing" do
+    it "parses --format argument" do
+      cmd = IssuesCommand.new(".meta/reps.toml")
+      output_dir = File.join(ISSUES_COMMAND_SPEC_TEMP_DIR, "format_test")
+
+      # The command should parse additional args
+      # We can test this indirectly by checking the format field changes
+      # Note: We can't easily test execute without mocking HTTP, but we can verify
+      # the command is created correctly
+      cmd.output_format.should eq("org")
+    end
+  end
+
+  describe "output format validation" do
+    it "accepts org format" do
+      cmd = IssuesCommand.new(".meta/reps.toml", output_format: "org")
+      cmd.output_format.should eq("org")
+    end
+
+    it "accepts md format" do
+      cmd = IssuesCommand.new(".meta/reps.toml", output_format: "md")
+      cmd.output_format.should eq("md")
+    end
+  end
+
+  describe "state filter validation" do
+    it "accepts 'open' state" do
+      cmd = IssuesCommand.new(".meta/reps.toml", state_filter: "open")
+      cmd.state_filter.should eq("open")
+    end
+
+    it "accepts 'closed' state" do
+      cmd = IssuesCommand.new(".meta/reps.toml", state_filter: "closed")
+      cmd.state_filter.should eq("closed")
+    end
+
+    it "accepts 'all' state" do
+      cmd = IssuesCommand.new(".meta/reps.toml", state_filter: "all")
+      cmd.state_filter.should eq("all")
+    end
+  end
+end

--- a/src/milka/command_factory.cr
+++ b/src/milka/command_factory.cr
@@ -5,6 +5,7 @@ require "./commands/push_command"
 require "./commands/scan_command"
 require "./commands/create_command"
 require "./commands/remote_command"
+require "./commands/issues_command"
 
 class CommandFactory
   def self.create_command(command_string : String, config_path : String, branch_override : String? = nil, use_subtree : Bool = false)
@@ -23,6 +24,8 @@ class CommandFactory
       CreateCommand.new(config_path, branch_override, use_subtree)
     when "remote"
       RemoteCommand.new(config_path, branch_override)
+    when "issues"
+      IssuesCommand.new(config_path, branch_override)
     else
       nil
     end

--- a/src/milka/commands.cr
+++ b/src/milka/commands.cr
@@ -31,6 +31,8 @@ def get_command_from_string(command_string : String)
     :create
   when "remote"
     :remote
+  when "issues"
+    :issues
   when "help"
     :help
   else
@@ -108,9 +110,10 @@ def main
     (non_option_args[2].starts_with?("http://") || non_option_args[2].starts_with?("https://"))
   )
 
-  # Load configuration for commands that need it (not for scan, create, or remote commands)
+  # Load configuration for commands that need it (not for scan, create, remote, or issues commands)
   # Also skip loading config if this is a URL clone operation
-  if command_string != "scan" && command_string != "init" && command_string != "create" && command_string != "remote" && !is_url_clone
+  # Issues command can work without config if a repo URL is provided
+  if command_string != "scan" && command_string != "init" && command_string != "create" && command_string != "remote" && command_string != "issues" && !is_url_clone
     begin
       config = ConfigManager.load_mise_config(config_path)
       Utils.print_info("Loaded #{config.repositories.size} repositories")
@@ -132,6 +135,20 @@ def main
       Utils.print_error("No repositories available to process. Check the warning above and your config file.")
       exit(1)
     end
+  elsif command_string == "issues"
+    # Issues command: try to load config but don't fail if not found
+    begin
+      config = ConfigManager.load_mise_config(config_path)
+      repositories = config.repositories
+      if branch_override
+        repositories = repositories.map do |repo|
+          RepositoryInfo.new(repo.name, repo.url, branch_override, repo.latest_commit, repo.source)
+        end
+      end
+    rescue e : GitError
+      # Config is optional for issues command, can work with URL directly
+      repositories = [] of RepositoryInfo
+    end
   end
 
   begin
@@ -144,7 +161,7 @@ def main
       exit(1)
     end
 
-    if command_string == "scan" || command_string == "create" || command_string == "remote" || command_string == "clone"
+    if command_string == "scan" || command_string == "create" || command_string == "remote" || command_string == "clone" || command_string == "issues"
       command.execute(repositories, repo_name, additional_args)
     else
       command.execute(repositories, repo_name)

--- a/src/milka/commands/issues_command.cr
+++ b/src/milka/commands/issues_command.cr
@@ -1,5 +1,6 @@
 require "../types/repository_info"
 require "../types/issue_info"
+require "../types/comment_info"
 require "../types/git_error"
 require "../providers/issue_provider"
 require "../providers/github_provider"
@@ -32,8 +33,8 @@ class IssuesCommand
     parse_additional_args(additional_args)
 
     # Validate format
-    unless ["org", "md"].includes?(@output_format)
-      raise GitError.new("Invalid output format '#{@output_format}'. Supported formats: org, md")
+    unless ["org", "md", "json"].includes?(@output_format)
+      raise GitError.new("Invalid output format '#{@output_format}'. Supported formats: org, md, json")
     end
 
     # Validate state filter
@@ -192,6 +193,8 @@ class IssuesCommand
       content = case @output_format
                 when "md"
                   issue.to_md
+                when "json"
+                  issue.to_json_ld
                 else
                   issue.to_org
                 end

--- a/src/milka/commands/issues_command.cr
+++ b/src/milka/commands/issues_command.cr
@@ -1,0 +1,209 @@
+require "../types/repository_info"
+require "../types/issue_info"
+require "../types/git_error"
+require "../providers/issue_provider"
+require "../providers/github_provider"
+require "../providers/forgejo_provider"
+require "../utils"
+require "../config_manager"
+
+# Command to download issues from repositories and save them as files
+class IssuesCommand
+  DEFAULT_OUTPUT_DIR = ".meta/issues"
+  DEFAULT_FORMAT = "org"
+
+  property config_path : String
+  property branch_override : String?
+  property output_format : String
+  property output_dir : String
+  property state_filter : String
+
+  def initialize(
+    @config_path : String,
+    @branch_override : String? = nil,
+    @output_format : String = DEFAULT_FORMAT,
+    @output_dir : String = DEFAULT_OUTPUT_DIR,
+    @state_filter : String = "all"
+  )
+  end
+
+  def execute(repositories : Array(RepositoryInfo)? = nil, repo_name : String? = nil, additional_args : Array(String) = [] of String)
+    # Parse additional arguments for format and state options
+    parse_additional_args(additional_args)
+
+    # Validate format
+    unless ["org", "md"].includes?(@output_format)
+      raise GitError.new("Invalid output format '#{@output_format}'. Supported formats: org, md")
+    end
+
+    # Validate state filter
+    unless ["open", "closed", "all"].includes?(@state_filter)
+      raise GitError.new("Invalid state filter '#{@state_filter}'. Supported states: open, closed, all")
+    end
+
+    # Ensure output directory exists
+    Dir.mkdir_p(@output_dir) unless Dir.exists?(@output_dir)
+
+    if repo_name
+      # Download issues for a specific repository
+      download_issues_for_repo_name(repo_name, repositories)
+    elsif repositories && !repositories.empty?
+      # Download issues for all repositories from config
+      download_issues_for_all(repositories)
+    else
+      Utils.print_error("No repositories specified. Either provide a repository name or ensure .meta/reps.toml has repositories configured.")
+      exit(1)
+    end
+  end
+
+  private def parse_additional_args(args : Array(String))
+    i = 0
+    while i < args.size
+      arg = args[i]
+      case arg
+      when "--format"
+        if i + 1 < args.size
+          @output_format = args[i + 1]
+          i += 2
+          next
+        end
+      when "--output", "-o"
+        if i + 1 < args.size
+          @output_dir = args[i + 1]
+          i += 2
+          next
+        end
+      when "--state"
+        if i + 1 < args.size
+          @state_filter = args[i + 1]
+          i += 2
+          next
+        end
+      end
+      i += 1
+    end
+  end
+
+  private def download_issues_for_repo_name(repo_name : String, repositories : Array(RepositoryInfo)?)
+    # First, try to find the repository in the config
+    repo = repositories.try { |repos| Utils.find_repository_in(repos, named: repo_name) }
+
+    if repo
+      download_issues_for_repository(repo)
+    else
+      # If not in config, check if repo_name looks like a URL
+      if repo_name.includes?("://") || repo_name.starts_with?("git@")
+        download_issues_for_url(repo_name)
+      else
+        # Try to parse as owner/repo format
+        if repo_name.includes?("/") && !repo_name.starts_with?("/")
+          parts = repo_name.split("/", 2)
+          if parts.size == 2
+            download_issues_for_owner_repo(parts[0], parts[1], "https://github.com")
+            return
+          end
+        end
+
+        Utils.print_error("Repository '#{repo_name}' not found in configuration and is not a valid URL or owner/repo format.")
+        exit(1)
+      end
+    end
+  end
+
+  private def download_issues_for_all(repositories : Array(RepositoryInfo))
+    Utils.print_info("Downloading issues for #{repositories.size} repositories...")
+
+    repositories.each_with_index do |repo, index|
+      Utils.print_info("[#{index + 1}/#{repositories.size}] Processing #{repo.name}")
+      begin
+        download_issues_for_repository(repo)
+      rescue e : GitError
+        Utils.print_warning("  Skipping #{repo.name}: #{e.message}")
+      end
+    end
+  end
+
+  private def download_issues_for_repository(repo : RepositoryInfo)
+    parsed = IssueProvider.parse_repo_url(repo.url)
+    unless parsed
+      raise GitError.new("Could not parse repository URL: #{repo.url}")
+    end
+
+    owner, repo_name = parsed
+    base_url = IssueProvider.extract_base_url(repo.url)
+
+    provider = create_provider_for_url(repo.url, base_url)
+    fetch_and_save_issues(provider, owner, repo_name, repo.name)
+  end
+
+  private def download_issues_for_url(url : String)
+    parsed = IssueProvider.parse_repo_url(url)
+    unless parsed
+      raise GitError.new("Could not parse repository URL: #{url}")
+    end
+
+    owner, repo_name = parsed
+    base_url = IssueProvider.extract_base_url(url)
+
+    provider = create_provider_for_url(url, base_url)
+    fetch_and_save_issues(provider, owner, repo_name, repo_name)
+  end
+
+  private def download_issues_for_owner_repo(owner : String, repo : String, base_url : String)
+    provider = GitHubIssueProvider.new
+    fetch_and_save_issues(provider, owner, repo, repo)
+  end
+
+  private def create_provider_for_url(url : String, base_url : String?) : IssueProvider
+    provider_type = IssueProvider.detect_provider_type(url)
+
+    case provider_type
+    when "github"
+      GitHubIssueProvider.new
+    when "forgejo"
+      ForgejoIssueProvider.new(base_url || "https://codeberg.org")
+    else
+      # Default to GitHub for unknown providers
+      GitHubIssueProvider.new
+    end
+  end
+
+  private def fetch_and_save_issues(provider : IssueProvider, owner : String, repo : String, local_name : String)
+    Utils.print_info("  Fetching issues from #{provider.name} (#{owner}/#{repo})...")
+
+    issues = provider.fetch_issues(owner, repo, @state_filter)
+
+    if issues.empty?
+      Utils.print_info("  No issues found.")
+      return
+    end
+
+    Utils.print_info("  Found #{issues.size} issues. Saving...")
+
+    # Create a subdirectory for each repository
+    repo_issues_dir = File.join(@output_dir, local_name)
+    Dir.mkdir_p(repo_issues_dir) unless Dir.exists?(repo_issues_dir)
+
+    saved_count = 0
+    issues.each do |issue|
+      filename = "#{issue.number}.#{@output_format}"
+      filepath = File.join(repo_issues_dir, filename)
+
+      content = case @output_format
+                when "md"
+                  issue.to_md
+                else
+                  issue.to_org
+                end
+
+      begin
+        File.write(filepath, content)
+        saved_count += 1
+      rescue e
+        Utils.print_warning("  Failed to save issue ##{issue.number}: #{e.message}")
+      end
+    end
+
+    Utils.print_success("  Saved #{saved_count} issues to #{repo_issues_dir}/")
+  end
+end

--- a/src/milka/providers/forgejo_provider.cr
+++ b/src/milka/providers/forgejo_provider.cr
@@ -1,0 +1,121 @@
+require "http/client"
+require "json"
+require "./issue_provider"
+require "../types/issue_info"
+require "../types/git_error"
+
+# Forgejo/Gitea issue provider - fetches issues from Forgejo/Gitea API
+# Also works with Codeberg and other Forgejo/Gitea-based instances
+class ForgejoIssueProvider < IssueProvider
+  USER_AGENT = "milka-cli"
+
+  property base_url : String
+
+  def initialize(@base_url : String = "https://codeberg.org")
+    # Ensure no trailing slash
+    @base_url = @base_url.rstrip('/')
+  end
+
+  def name : String
+    "Forgejo"
+  end
+
+  def fetch_issues(owner : String, repo : String, state : String = "all") : Array(IssueInfo)
+    issues = [] of IssueInfo
+    page = 1
+    limit = 50
+
+    loop do
+      url = "#{@base_url}/api/v1/repos/#{owner}/#{repo}/issues?state=#{state}&page=#{page}&limit=#{limit}"
+
+      response = make_request(url)
+
+      case response.status_code
+      when 200
+        parsed_issues = parse_issues_response(response.body)
+        break if parsed_issues.empty?
+
+        issues.concat(parsed_issues)
+        page += 1
+
+        # If we got less than limit results, we've reached the end
+        break if parsed_issues.size < limit
+      when 401
+        raise GitError.new("Forgejo API: Authentication required. Set FORGEJO_TOKEN environment variable for private repositories.")
+      when 403
+        raise GitError.new("Forgejo API: Access forbidden. Repository may be private - set FORGEJO_TOKEN environment variable.")
+      when 404
+        raise GitError.new("Forgejo API: Repository '#{owner}/#{repo}' not found at #{@base_url}.")
+      else
+        raise GitError.new("Forgejo API error: HTTP #{response.status_code} - #{response.body}")
+      end
+    end
+
+    issues
+  end
+
+  private def make_request(url : String) : HTTP::Client::Response
+    uri = URI.parse(url)
+
+    HTTP::Client.new(uri) do |client|
+      client.connect_timeout = 30.seconds
+      client.read_timeout = 30.seconds
+
+      headers = HTTP::Headers{
+        "User-Agent" => USER_AGENT,
+        "Accept"     => "application/json",
+      }
+
+      # Use FORGEJO_TOKEN if available for authentication
+      if token = ENV["FORGEJO_TOKEN"]?
+        headers["Authorization"] = "token #{token}"
+      end
+
+      query_string = uri.query ? "?#{uri.query}" : ""
+      return client.get(uri.path.not_nil! + query_string, headers: headers)
+    end
+  end
+
+  private def parse_issues_response(body : String) : Array(IssueInfo)
+    issues = [] of IssueInfo
+
+    begin
+      json = JSON.parse(body)
+
+      json.as_a.each do |item|
+        # Forgejo API includes pull_requests in separate endpoint, but check anyway
+        next if item["pull_request"]?
+
+        number = item["number"].as_i
+        title = item["title"].as_s
+        body_text = item["body"]?.try(&.as_s?) || ""
+        state = item["state"].as_s
+        created_at = item["created_at"].as_s
+        updated_at = item["updated_at"].as_s
+        author = item["user"]?.try(&.["login"]?.try(&.as_s)) || "unknown"
+        html_url = item["html_url"]?.try(&.as_s) || ""
+
+        labels = [] of String
+        if label_arr = item["labels"]?.try(&.as_a?)
+          labels = label_arr.compact_map { |l| l["name"]?.try(&.as_s) }
+        end
+
+        issues << IssueInfo.new(
+          number: number,
+          title: title,
+          body: body_text,
+          state: state,
+          created_at: created_at,
+          updated_at: updated_at,
+          author: author,
+          labels: labels,
+          html_url: html_url
+        )
+      end
+    rescue e : JSON::ParseException
+      raise GitError.new("Failed to parse Forgejo API response: #{e.message}")
+    end
+
+    issues
+  end
+end

--- a/src/milka/providers/forgejo_provider.cr
+++ b/src/milka/providers/forgejo_provider.cr
@@ -2,6 +2,7 @@ require "http/client"
 require "json"
 require "./issue_provider"
 require "../types/issue_info"
+require "../types/comment_info"
 require "../types/git_error"
 
 # Forgejo/Gitea issue provider - fetches issues from Forgejo/Gitea API
@@ -10,8 +11,9 @@ class ForgejoIssueProvider < IssueProvider
   USER_AGENT = "milka-cli"
 
   property base_url : String
+  property fetch_comments : Bool
 
-  def initialize(@base_url : String = "https://codeberg.org")
+  def initialize(@base_url : String = "https://codeberg.org", @fetch_comments : Bool = true)
     # Ensure no trailing slash
     @base_url = @base_url.rstrip('/')
   end
@@ -32,7 +34,7 @@ class ForgejoIssueProvider < IssueProvider
 
       case response.status_code
       when 200
-        parsed_issues = parse_issues_response(response.body)
+        parsed_issues = parse_issues_response(response.body, owner, repo)
         break if parsed_issues.empty?
 
         issues.concat(parsed_issues)
@@ -51,7 +53,61 @@ class ForgejoIssueProvider < IssueProvider
       end
     end
 
+    # Fetch comments for each issue if enabled
+    if @fetch_comments
+      issues.each do |issue|
+        fetch_comments_for_issue(owner, repo, issue)
+      end
+    end
+
     issues
+  end
+
+  private def fetch_comments_for_issue(owner : String, repo : String, issue : IssueInfo)
+    url = "#{@base_url}/api/v1/repos/#{owner}/#{repo}/issues/#{issue.number}/comments"
+
+    begin
+      response = make_request(url)
+
+      if response.status_code == 200
+        comments = parse_comments_response(response.body)
+        issue.comments = comments
+      end
+    rescue
+      # Silently ignore comment fetch errors - issue data is still valuable
+    end
+  end
+
+  private def parse_comments_response(body : String) : Array(CommentInfo)
+    comments = [] of CommentInfo
+
+    begin
+      json = JSON.parse(body)
+
+      json.as_a.each do |item|
+        id = item["id"].as_i64
+        body_text = item["body"]?.try(&.as_s?) || ""
+        author = item["user"]?.try(&.["login"]?.try(&.as_s)) || "unknown"
+        author_url = item["user"]?.try(&.["html_url"]?.try(&.as_s)) || ""
+        created_at = item["created_at"]?.try(&.as_s) || ""
+        updated_at = item["updated_at"]?.try(&.as_s) || ""
+        html_url = item["html_url"]?.try(&.as_s) || ""
+
+        comments << CommentInfo.new(
+          id: id,
+          body: body_text,
+          author: author,
+          author_url: author_url,
+          created_at: created_at,
+          updated_at: updated_at,
+          html_url: html_url
+        )
+      end
+    rescue e : JSON::ParseException
+      # Return empty array on parse error
+    end
+
+    comments
   end
 
   private def make_request(url : String) : HTTP::Client::Response
@@ -76,8 +132,9 @@ class ForgejoIssueProvider < IssueProvider
     end
   end
 
-  private def parse_issues_response(body : String) : Array(IssueInfo)
+  private def parse_issues_response(body : String, owner : String, repo : String) : Array(IssueInfo)
     issues = [] of IssueInfo
+    context_url = "#{@base_url}/#{owner}/#{repo}"
 
     begin
       json = JSON.parse(body)
@@ -93,6 +150,7 @@ class ForgejoIssueProvider < IssueProvider
         created_at = item["created_at"].as_s
         updated_at = item["updated_at"].as_s
         author = item["user"]?.try(&.["login"]?.try(&.as_s)) || "unknown"
+        author_url = item["user"]?.try(&.["html_url"]?.try(&.as_s)) || ""
         html_url = item["html_url"]?.try(&.as_s) || ""
 
         labels = [] of String
@@ -108,8 +166,10 @@ class ForgejoIssueProvider < IssueProvider
           created_at: created_at,
           updated_at: updated_at,
           author: author,
+          author_url: author_url,
           labels: labels,
-          html_url: html_url
+          html_url: html_url,
+          context_url: context_url
         )
       end
     rescue e : JSON::ParseException

--- a/src/milka/providers/github_provider.cr
+++ b/src/milka/providers/github_provider.cr
@@ -2,12 +2,18 @@ require "http/client"
 require "json"
 require "./issue_provider"
 require "../types/issue_info"
+require "../types/comment_info"
 require "../types/git_error"
 
 # GitHub issue provider - fetches issues from GitHub API
 class GitHubIssueProvider < IssueProvider
   API_BASE = "https://api.github.com"
   USER_AGENT = "milka-cli"
+
+  property fetch_comments : Bool
+
+  def initialize(@fetch_comments : Bool = true)
+  end
 
   def name : String
     "GitHub"
@@ -25,7 +31,7 @@ class GitHubIssueProvider < IssueProvider
 
       case response.status_code
       when 200
-        parsed_issues = parse_issues_response(response.body)
+        parsed_issues = parse_issues_response(response.body, owner, repo)
         break if parsed_issues.empty?
 
         issues.concat(parsed_issues)
@@ -49,7 +55,61 @@ class GitHubIssueProvider < IssueProvider
       end
     end
 
+    # Fetch comments for each issue if enabled
+    if @fetch_comments
+      issues.each do |issue|
+        fetch_comments_for_issue(owner, repo, issue)
+      end
+    end
+
     issues
+  end
+
+  private def fetch_comments_for_issue(owner : String, repo : String, issue : IssueInfo)
+    url = "#{API_BASE}/repos/#{owner}/#{repo}/issues/#{issue.number}/comments"
+
+    begin
+      response = make_request(url)
+
+      if response.status_code == 200
+        comments = parse_comments_response(response.body)
+        issue.comments = comments
+      end
+    rescue
+      # Silently ignore comment fetch errors - issue data is still valuable
+    end
+  end
+
+  private def parse_comments_response(body : String) : Array(CommentInfo)
+    comments = [] of CommentInfo
+
+    begin
+      json = JSON.parse(body)
+
+      json.as_a.each do |item|
+        id = item["id"].as_i64
+        body_text = item["body"]?.try(&.as_s?) || ""
+        author = item["user"]?.try(&.["login"]?.try(&.as_s)) || "unknown"
+        author_url = item["user"]?.try(&.["html_url"]?.try(&.as_s)) || ""
+        created_at = item["created_at"]?.try(&.as_s) || ""
+        updated_at = item["updated_at"]?.try(&.as_s) || ""
+        html_url = item["html_url"]?.try(&.as_s) || ""
+
+        comments << CommentInfo.new(
+          id: id,
+          body: body_text,
+          author: author,
+          author_url: author_url,
+          created_at: created_at,
+          updated_at: updated_at,
+          html_url: html_url
+        )
+      end
+    rescue e : JSON::ParseException
+      # Return empty array on parse error
+    end
+
+    comments
   end
 
   private def make_request(url : String) : HTTP::Client::Response
@@ -69,12 +129,14 @@ class GitHubIssueProvider < IssueProvider
         headers["Authorization"] = "token #{token}"
       end
 
-      return client.get(uri.path.not_nil! + "?" + uri.query.not_nil!, headers: headers)
+      query = uri.query ? "?#{uri.query}" : ""
+      return client.get(uri.path.not_nil! + query, headers: headers)
     end
   end
 
-  private def parse_issues_response(body : String) : Array(IssueInfo)
+  private def parse_issues_response(body : String, owner : String, repo : String) : Array(IssueInfo)
     issues = [] of IssueInfo
+    context_url = "https://github.com/#{owner}/#{repo}"
 
     begin
       json = JSON.parse(body)
@@ -90,6 +152,7 @@ class GitHubIssueProvider < IssueProvider
         created_at = item["created_at"].as_s
         updated_at = item["updated_at"].as_s
         author = item["user"]?.try(&.["login"]?.try(&.as_s)) || "unknown"
+        author_url = item["user"]?.try(&.["html_url"]?.try(&.as_s)) || ""
         html_url = item["html_url"]?.try(&.as_s) || ""
 
         labels = [] of String
@@ -105,8 +168,10 @@ class GitHubIssueProvider < IssueProvider
           created_at: created_at,
           updated_at: updated_at,
           author: author,
+          author_url: author_url,
           labels: labels,
-          html_url: html_url
+          html_url: html_url,
+          context_url: context_url
         )
       end
     rescue e : JSON::ParseException

--- a/src/milka/providers/github_provider.cr
+++ b/src/milka/providers/github_provider.cr
@@ -1,0 +1,118 @@
+require "http/client"
+require "json"
+require "./issue_provider"
+require "../types/issue_info"
+require "../types/git_error"
+
+# GitHub issue provider - fetches issues from GitHub API
+class GitHubIssueProvider < IssueProvider
+  API_BASE = "https://api.github.com"
+  USER_AGENT = "milka-cli"
+
+  def name : String
+    "GitHub"
+  end
+
+  def fetch_issues(owner : String, repo : String, state : String = "all") : Array(IssueInfo)
+    issues = [] of IssueInfo
+    page = 1
+    per_page = 100
+
+    loop do
+      url = "#{API_BASE}/repos/#{owner}/#{repo}/issues?state=#{state}&page=#{page}&per_page=#{per_page}"
+
+      response = make_request(url)
+
+      case response.status_code
+      when 200
+        parsed_issues = parse_issues_response(response.body)
+        break if parsed_issues.empty?
+
+        issues.concat(parsed_issues)
+        page += 1
+
+        # GitHub returns both issues and PRs in the issues endpoint
+        # If we got less than per_page results, we've reached the end
+        break if parsed_issues.size < per_page
+      when 401
+        raise GitError.new("GitHub API: Authentication required. Set GITHUB_TOKEN environment variable for private repositories.")
+      when 403
+        if response.headers["X-RateLimit-Remaining"]? == "0"
+          raise GitError.new("GitHub API rate limit exceeded. Try again later or set GITHUB_TOKEN environment variable.")
+        else
+          raise GitError.new("GitHub API: Access forbidden. Repository may be private - set GITHUB_TOKEN environment variable.")
+        end
+      when 404
+        raise GitError.new("GitHub API: Repository '#{owner}/#{repo}' not found.")
+      else
+        raise GitError.new("GitHub API error: HTTP #{response.status_code} - #{response.body}")
+      end
+    end
+
+    issues
+  end
+
+  private def make_request(url : String) : HTTP::Client::Response
+    uri = URI.parse(url)
+
+    HTTP::Client.new(uri) do |client|
+      client.connect_timeout = 30.seconds
+      client.read_timeout = 30.seconds
+
+      headers = HTTP::Headers{
+        "User-Agent" => USER_AGENT,
+        "Accept"     => "application/vnd.github.v3+json",
+      }
+
+      # Use GITHUB_TOKEN if available for authentication
+      if token = ENV["GITHUB_TOKEN"]?
+        headers["Authorization"] = "token #{token}"
+      end
+
+      return client.get(uri.path.not_nil! + "?" + uri.query.not_nil!, headers: headers)
+    end
+  end
+
+  private def parse_issues_response(body : String) : Array(IssueInfo)
+    issues = [] of IssueInfo
+
+    begin
+      json = JSON.parse(body)
+
+      json.as_a.each do |item|
+        # Skip pull requests (they have a "pull_request" key)
+        next if item["pull_request"]?
+
+        number = item["number"].as_i
+        title = item["title"].as_s
+        body_text = item["body"]?.try(&.as_s?) || ""
+        state = item["state"].as_s
+        created_at = item["created_at"].as_s
+        updated_at = item["updated_at"].as_s
+        author = item["user"]?.try(&.["login"]?.try(&.as_s)) || "unknown"
+        html_url = item["html_url"]?.try(&.as_s) || ""
+
+        labels = [] of String
+        if label_arr = item["labels"]?.try(&.as_a?)
+          labels = label_arr.compact_map { |l| l["name"]?.try(&.as_s) }
+        end
+
+        issues << IssueInfo.new(
+          number: number,
+          title: title,
+          body: body_text,
+          state: state,
+          created_at: created_at,
+          updated_at: updated_at,
+          author: author,
+          labels: labels,
+          html_url: html_url
+        )
+      end
+    rescue e : JSON::ParseException
+      raise GitError.new("Failed to parse GitHub API response: #{e.message}")
+    end
+
+    issues
+  end
+end

--- a/src/milka/providers/issue_provider.cr
+++ b/src/milka/providers/issue_provider.cr
@@ -1,0 +1,72 @@
+require "../types/issue_info"
+require "../types/git_error"
+
+# Abstract base class for issue providers (GitHub, Forgejo, etc.)
+# This allows for extensibility - new providers can be added by inheriting from this class
+abstract class IssueProvider
+  # Fetch issues from the provider
+  # @param owner - repository owner
+  # @param repo - repository name
+  # @param state - "open", "closed", or "all"
+  # @return Array of IssueInfo objects
+  abstract def fetch_issues(owner : String, repo : String, state : String = "all") : Array(IssueInfo)
+
+  # Get the provider name (for display purposes)
+  abstract def name : String
+
+  # Parse a repository URL to extract owner and repo
+  # @return Tuple of (owner, repo) or nil if cannot be parsed
+  def self.parse_repo_url(url : String) : {String, String}?
+    # GitHub format: https://github.com/owner/repo[.git]
+    # Forgejo format: https://codeberg.org/owner/repo[.git] (or any host)
+    # SSH format: git@github.com:owner/repo.git
+
+    # Handle SSH format
+    if url.starts_with?("git@")
+      # git@github.com:owner/repo.git
+      if match = url.match(/git@[^:]+:([^\/]+)\/([^\.]+)(\.git)?$/)
+        return {match[1], match[2]}
+      end
+    end
+
+    # Handle HTTPS format
+    if url.includes?("://")
+      # Remove trailing .git if present
+      clean_url = url.gsub(/\.git$/, "")
+      # Extract path after domain
+      if match = clean_url.match(/https?:\/\/[^\/]+\/([^\/]+)\/([^\/\?#]+)/)
+        return {match[1], match[2]}
+      end
+    end
+
+    nil
+  end
+
+  # Detect provider type from URL
+  def self.detect_provider_type(url : String) : String
+    if url.includes?("github.com")
+      "github"
+    elsif url.includes?("codeberg.org") || url.includes?("gitea") || url.includes?("forgejo")
+      "forgejo"
+    else
+      # Default to forgejo for generic git hosts (since it uses a common API)
+      "forgejo"
+    end
+  end
+
+  # Extract the base URL (host) from a repository URL
+  def self.extract_base_url(url : String) : String?
+    if url.starts_with?("git@")
+      # git@github.com:owner/repo.git -> github.com
+      if match = url.match(/git@([^:]+):/)
+        return "https://#{match[1]}"
+      end
+    end
+
+    if match = url.match(/(https?:\/\/[^\/]+)/)
+      return match[1]
+    end
+
+    nil
+  end
+end

--- a/src/milka/types/comment_info.cr
+++ b/src/milka/types/comment_info.cr
@@ -1,0 +1,90 @@
+# Information about a single comment on an issue
+class CommentInfo
+  property id : Int64
+  property body : String
+  property author : String
+  property author_url : String
+  property created_at : String
+  property updated_at : String
+  property html_url : String
+
+  def initialize(
+    @id : Int64,
+    @body : String = "",
+    @author : String = "",
+    @author_url : String = "",
+    @created_at : String = "",
+    @updated_at : String = "",
+    @html_url : String = ""
+  )
+  end
+
+  # Format comment as org-mode format
+  # Using the requested format:
+  # #+begin_comments
+  # :PROPERTIES:
+  # :author: author link in org format
+  # :id: comment_id
+  # :END:
+  # {{ comment content }}
+  # #+end_comments
+  def to_org : String
+    String.build do |str|
+      str << ":PROPERTIES:\n"
+      if @author_url.empty?
+        str << ":author: #{@author}\n"
+      else
+        str << ":author: [[#{@author_url}][#{@author}]]\n"
+      end
+      str << ":id: #{@id}\n"
+      str << ":END:\n"
+      str << @body
+      str << "\n"
+    end
+  end
+
+  # Format comment as markdown/HTML format
+  # Using the requested format:
+  # <comments-comment
+  # author="author_link"
+  # id="id"
+  # >
+  # {{ comment content }}
+  # </comments-comment>
+  def to_md : String
+    author_attr = @author_url.empty? ? @author : @author_url
+    String.build do |str|
+      str << "<comments-comment\n"
+      str << "author=\"#{author_attr}\"\n"
+      str << "id=\"#{@id}\"\n"
+      str << ">\n"
+      str << @body
+      str << "\n</comments-comment>\n"
+    end
+  end
+
+  # Format comment as JSON-LD (ForgeFed Note format)
+  def to_json_ld : String
+    String.build do |str|
+      str << "{\n"
+      str << "  \"type\": \"Note\",\n"
+      str << "  \"id\": #{@id},\n"
+      str << "  \"attributedTo\": \"#{escape_json(@author_url.empty? ? @author : @author_url)}\",\n"
+      str << "  \"content\": \"#{escape_json(@body)}\",\n"
+      str << "  \"mediaType\": \"text/markdown\",\n"
+      str << "  \"published\": \"#{@created_at}\""
+      unless @html_url.empty?
+        str << ",\n  \"url\": \"#{escape_json(@html_url)}\""
+      end
+      str << "\n}"
+    end
+  end
+
+  private def escape_json(str : String) : String
+    str.gsub("\\", "\\\\")
+       .gsub("\"", "\\\"")
+       .gsub("\n", "\\n")
+       .gsub("\r", "\\r")
+       .gsub("\t", "\\t")
+  end
+end

--- a/src/milka/types/git_error.cr
+++ b/src/milka/types/git_error.cr
@@ -39,4 +39,16 @@ class GitError < Exception
   def self.subtree_push_failed(message)
     new("Subtree push failed: #{message}")
   end
+
+  def self.issues_fetch_failed(message)
+    new("Issues fetch failed: #{message}")
+  end
+
+  def self.issues_api_error(message)
+    new("Issues API error: #{message}")
+  end
+
+  def self.issues_invalid_format(message)
+    new("Invalid issues format: #{message}")
+  end
 end

--- a/src/milka/types/issue_info.cr
+++ b/src/milka/types/issue_info.cr
@@ -1,3 +1,5 @@
+require "./comment_info"
+
 # Information about a single issue from a repository
 class IssueInfo
   property number : Int32
@@ -7,8 +9,11 @@ class IssueInfo
   property created_at : String
   property updated_at : String
   property author : String
+  property author_url : String
   property labels : Array(String)
   property html_url : String
+  property comments : Array(CommentInfo)
+  property context_url : String # Repository/tracker URL for JSON-LD
 
   def initialize(
     @number : Int32,
@@ -18,8 +23,11 @@ class IssueInfo
     @created_at : String = "",
     @updated_at : String = "",
     @author : String = "",
+    @author_url : String = "",
     @labels : Array(String) = [] of String,
-    @html_url : String = ""
+    @html_url : String = "",
+    @comments : Array(CommentInfo) = [] of CommentInfo,
+    @context_url : String = ""
   )
   end
 
@@ -36,10 +44,20 @@ class IssueInfo
       str << "\n"
       str << @body
       str << "\n"
+
+      # Add comments section if there are comments
+      unless @comments.empty?
+        str << "\n#+begin_comments\n"
+        @comments.each do |comment|
+          str << comment.to_org
+        end
+        str << "#+end_comments\n"
+      end
     end
   end
 
   # Format issue as .md (Markdown) file content
+  # Note: Title is only in YAML frontmatter, not duplicated as a heading
   def to_md : String
     String.build do |str|
       str << "---\n"
@@ -51,13 +69,76 @@ class IssueInfo
       str << "url: #{@html_url}\n" unless @html_url.empty?
       str << "labels: [#{@labels.map { |l| "\"#{escape_yaml(l)}\"" }.join(", ")}]\n" unless @labels.empty?
       str << "---\n\n"
-      str << "# #{@title}\n\n"
       str << @body
       str << "\n"
+
+      # Add comments section if there are comments
+      unless @comments.empty?
+        str << "\n<begin-comments>\n"
+        @comments.each do |comment|
+          str << comment.to_md
+        end
+        str << "</begin-comments>\n"
+      end
+    end
+  end
+
+  # Format issue as JSON-LD (ForgeFed Ticket format)
+  def to_json_ld : String
+    String.build do |str|
+      str << "{\n"
+      str << "  \"@context\": [\n"
+      str << "    \"https://www.w3.org/ns/activitystreams\",\n"
+      str << "    \"https://forgefed.org/ns\"\n"
+      str << "  ],\n"
+      str << "  \"id\": \"#{escape_json(@html_url)}\",\n"
+      str << "  \"type\": \"Ticket\",\n"
+      str << "  \"context\": \"#{escape_json(@context_url)}\",\n" unless @context_url.empty?
+      str << "  \"attributedTo\": \"#{escape_json(@author_url.empty? ? @author : @author_url)}\",\n"
+      str << "  \"summary\": \"#{escape_json(@title)}\",\n"
+      str << "  \"content\": \"#{escape_json(@body)}\",\n"
+      str << "  \"mediaType\": \"text/markdown\",\n"
+      str << "  \"published\": \"#{@created_at}\",\n"
+      str << "  \"updated\": \"#{@updated_at}\",\n" unless @updated_at.empty?
+      str << "  \"isResolved\": #{@state == "closed"},\n"
+
+      # Add labels as tags
+      unless @labels.empty?
+        str << "  \"tag\": [\n"
+        @labels.each_with_index do |label, idx|
+          str << "    {\"type\": \"Label\", \"name\": \"#{escape_json(label)}\"}"
+          str << "," if idx < @labels.size - 1
+          str << "\n"
+        end
+        str << "  ],\n"
+      end
+
+      # Add comments as replies
+      if @comments.empty?
+        str << "  \"replies\": []\n"
+      else
+        str << "  \"replies\": [\n"
+        @comments.each_with_index do |comment, idx|
+          str << "    " << comment.to_json_ld.gsub("\n", "\n    ")
+          str << "," if idx < @comments.size - 1
+          str << "\n"
+        end
+        str << "  ]\n"
+      end
+
+      str << "}"
     end
   end
 
   private def escape_yaml(str : String) : String
     str.gsub("\"", "\\\"")
+  end
+
+  private def escape_json(str : String) : String
+    str.gsub("\\", "\\\\")
+       .gsub("\"", "\\\"")
+       .gsub("\n", "\\n")
+       .gsub("\r", "\\r")
+       .gsub("\t", "\\t")
   end
 end

--- a/src/milka/types/issue_info.cr
+++ b/src/milka/types/issue_info.cr
@@ -1,0 +1,63 @@
+# Information about a single issue from a repository
+class IssueInfo
+  property number : Int32
+  property title : String
+  property body : String
+  property state : String
+  property created_at : String
+  property updated_at : String
+  property author : String
+  property labels : Array(String)
+  property html_url : String
+
+  def initialize(
+    @number : Int32,
+    @title : String,
+    @body : String = "",
+    @state : String = "open",
+    @created_at : String = "",
+    @updated_at : String = "",
+    @author : String = "",
+    @labels : Array(String) = [] of String,
+    @html_url : String = ""
+  )
+  end
+
+  # Format issue as .org file content
+  def to_org : String
+    String.build do |str|
+      str << "#+title: #{@title}\n"
+      str << "#+id: #{@number}\n"
+      str << "#+date: #{@created_at}\n"
+      str << "#+state: #{@state}\n"
+      str << "#+author: #{@author}\n"
+      str << "#+url: #{@html_url}\n" unless @html_url.empty?
+      str << "#+labels: #{@labels.join(", ")}\n" unless @labels.empty?
+      str << "\n"
+      str << @body
+      str << "\n"
+    end
+  end
+
+  # Format issue as .md (Markdown) file content
+  def to_md : String
+    String.build do |str|
+      str << "---\n"
+      str << "title: \"#{escape_yaml(@title)}\"\n"
+      str << "id: #{@number}\n"
+      str << "date: #{@created_at}\n"
+      str << "state: #{@state}\n"
+      str << "author: #{@author}\n"
+      str << "url: #{@html_url}\n" unless @html_url.empty?
+      str << "labels: [#{@labels.map { |l| "\"#{escape_yaml(l)}\"" }.join(", ")}]\n" unless @labels.empty?
+      str << "---\n\n"
+      str << "# #{@title}\n\n"
+      str << @body
+      str << "\n"
+    end
+  end
+
+  private def escape_yaml(str : String) : String
+    str.gsub("\"", "\\\"")
+  end
+end

--- a/src/milka/utils.cr
+++ b/src/milka/utils.cr
@@ -42,11 +42,21 @@ module Utils
       scan                 Scan for git repositories in the current directory and add them to reps.toml
       create <repo-name> [remote-url]   Create a new git repository and optionally set its remote
       remote <repo-name> <remote-url>   Add a remote to a local git repository
+      issues [repo-name]   Download issues from repositories to .meta/issues/ directory
       help                 Show this help message
 
     Options:
       --config <path>      Path to reps.toml configuration file (default: ./.meta/reps.toml)
       --branch <branch>    Specify branch (default: from config or main)
+
+    Issues Options:
+      --format <format>    Output format: org (default) or md
+      --output <path>      Output directory (default: .meta/issues)
+      --state <state>      Filter by state: open, closed, or all (default: all)
+
+    Environment Variables:
+      GITHUB_TOKEN         Token for GitHub API (required for private repos)
+      FORGEJO_TOKEN        Token for Forgejo/Gitea API (required for private repos)
 
     Examples:
       milka clone                    Clone all repositories from reps.toml
@@ -63,6 +73,12 @@ module Utils
       milka create my-repo https://example.com/user/repo.git    Create a new git repository with remote
       milka create my-subtree --subtree  Create a subtree git repository in existing directory
       milka remote my-repo https://example.com/user/repo.git    Add remote to a local git repository
+      milka issues                   Download issues for all repos in config
+      milka issues my-repo           Download issues for specific repo from config
+      milka issues owner/repo        Download issues from GitHub owner/repo
+      milka issues https://github.com/owner/repo    Download issues from URL
+      milka issues my-repo --format md    Download issues as Markdown files
+      milka issues my-repo --state open   Download only open issues
       milka --config /path/to/reps.toml clone
       milka --config /path/to/reps.toml --branch feature-branch clone my-repo
     USAGE


### PR DESCRIPTION
## Summary

Add a new `issues` command that fetches issues from repositories and saves them as structured `.org`, `.md`, or `.json` files with frontmatter metadata and comments.

### Features
- Support for **GitHub** and **Forgejo/Gitea** providers (extensible architecture)
- Download issues from config repos or directly via URL/owner/repo format
- Configurable output format (`.org`, `.md`, `.json`) and state filter (`open`, `closed`, `all`)
- Issues saved to `.meta/issues/<repo-name>/` directory
- YAML frontmatter for Markdown, org-mode headers for `.org` files
- **JSON-LD format** following [ForgeFed Ticket spec](https://forgefed.org/spec/#issues)
- **Comments sync** with org-mode PROPERTIES drawer and HTML elements for markdown
- Authentication via `GITHUB_TOKEN` and `FORGEJO_TOKEN` environment variables

### Usage Examples
```bash
# Download issues for all repos in config
milka issues

# Download issues for specific repo from config
milka issues my-repo

# Download issues from GitHub owner/repo
milka issues owner/repo

# Download issues from URL
milka issues https://github.com/owner/repo

# Download issues as Markdown files
milka issues my-repo --format md

# Download issues as JSON-LD files (ForgeFed format)
milka issues my-repo --format json

# Download only open issues
milka issues my-repo --state open
```

### File Formats

**Org format (default):**
```org
#+title: Issue Title
#+id: 42
#+date: 2024-01-15T10:00:00Z
#+state: open
#+author: username
#+url: https://github.com/owner/repo/issues/42
#+labels: bug, help wanted

Issue body content here...

#+begin_comments
:PROPERTIES:
:author: [[https://github.com/commenter][commenter]]
:id: 123
:END:
Comment content here...
#+end_comments
```

**Markdown format:**
```markdown
---
title: "Issue Title"
id: 42
date: 2024-01-15T10:00:00Z
state: open
author: username
url: https://github.com/owner/repo/issues/42
labels: ["bug", "help wanted"]
---

Issue body content here...

<begin-comments>
<comments-comment
author="https://github.com/commenter"
id="123"
>
Comment content here...
</comments-comment>
</begin-comments>
```

**JSON-LD format (ForgeFed Ticket):**
```json
{
  "@context": [
    "https://www.w3.org/ns/activitystreams",
    "https://forgefed.org/ns"
  ],
  "id": "https://github.com/owner/repo/issues/42",
  "type": "Ticket",
  "context": "https://github.com/owner/repo",
  "attributedTo": "https://github.com/username",
  "summary": "Issue Title",
  "content": "Issue body content here...",
  "mediaType": "text/markdown",
  "published": "2024-01-15T10:00:00Z",
  "isResolved": false,
  "replies": [
    {
      "type": "Note",
      "id": 123,
      "attributedTo": "https://github.com/commenter",
      "content": "Comment content here...",
      "mediaType": "text/markdown",
      "published": "2024-01-15T11:00:00Z"
    }
  ]
}
```

## Changes in this update

- **Fixed markdown title duplication** - Title is now only in YAML frontmatter, not duplicated as a heading
- **Added comments sync** - Comments are fetched and included in all output formats
- **Added JSON-LD format** - ForgeFed Ticket spec compliant JSON-LD output

## Test plan
- [x] Unit tests for IssueInfo formatting (org, md, json)
- [x] Unit tests for CommentInfo formatting
- [x] Unit tests for IssueProvider URL parsing
- [x] Unit tests for IssuesCommand initialization
- [x] CI builds and passes all tests
- [ ] Manual testing with real GitHub repositories

Fixes kogeletey/milka#3

🤖 Generated with [Claude Code](https://claude.com/claude-code)